### PR TITLE
fix: circular inheritance

### DIFF
--- a/src/ERDoc/linter/entity/checkEntityDuplicateAttribute.ts
+++ b/src/ERDoc/linter/entity/checkEntityDuplicateAttribute.ts
@@ -41,18 +41,22 @@ export const checkEntityDuplicateAttribute = (
 };
 
 const getAllAttributes = (entityName: string, er: ER) => {
-  let entity = er.entities.filter((e) => e.name === entityName).pop()!;
-  const entityAttributes = entity.attributes.map((attr) => ({
+  let currentEntity = er.entities.filter((e) => e.name === entityName).pop()!;
+  const entityAttributes = currentEntity.attributes.map((attr) => ({
     isFromParent: false,
     ...attr,
   }));
 
-  if (!entity.hasParent) return entityAttributes;
+  if (!currentEntity.hasParent) return entityAttributes;
   let hasParent = true;
   while (hasParent) {
     // assume only one parent, more than 1 would be an error caught by another validator
-    const parent = er.entities.filter((e) => e.name === entity.parentName);
+    const parent = er.entities.filter(
+      (e) => e.name === currentEntity.parentName,
+    );
     if (parent.length === 0) break;
+    // if it reaches itself it's a circular inheritance. WRONG.
+    if (parent[0].name === entityName) return [];
 
     parent[0].attributes.forEach((attr) => {
       entityAttributes.push({
@@ -61,8 +65,8 @@ const getAllAttributes = (entityName: string, er: ER) => {
       });
     });
 
-    entity = parent[0];
-    hasParent = entity.hasParent;
+    currentEntity = parent[0];
+    hasParent = currentEntity.hasParent;
   }
   return entityAttributes;
 };

--- a/src/ERDoc/linter/entity/checkEntityExtendsChild.ts
+++ b/src/ERDoc/linter/entity/checkEntityExtendsChild.ts
@@ -1,0 +1,48 @@
+import { ER } from "../../types/parser/ER";
+import { EntityExtendsChildEntityError } from "../../types/linter/SemanticError";
+
+/**
+ * Finds entities that extend a child entity in an ER object
+ * @param {ER} er - The ER object to lint
+ * @return {EntityExtendsChildEntityError[]} An array of errors for each entity that extends a child entity
+ */
+export const checkEntityExtendsChildEntity = (
+  er: ER,
+): EntityExtendsChildEntityError[] => {
+  const errors: EntityExtendsChildEntityError[] = [];
+  const inheritsFrom = new Map<string, string[]>();
+  for (const entity of er.entities) {
+    if (inheritsFrom.has(entity.name)) {
+      const parentInMap = inheritsFrom
+        .get(entity.name)!
+        .find((name) => name === entity.parentName);
+      if (parentInMap !== undefined)
+        errors.push({
+          type: "ENTITY_EXTENDS_CHILD_ENTITY",
+          parentEntityName: entity.name,
+          childEntityName: entity.parentName!,
+          location: entity.location,
+        });
+    }
+
+    if (!entity.hasParent) continue;
+    let parent = er.entities.find((e) => e.name === entity.parentName);
+    while (parent !== undefined && parent!.name !== entity.name) {
+      // parent can't be in my childs
+      const myChilds = inheritsFrom.get(entity.name);
+      if (myChilds !== undefined) {
+        const parentInMyChilds = myChilds.find((name) => name === parent!.name);
+        if (parentInMyChilds !== undefined) break;
+      }
+
+      if (inheritsFrom.has(parent.name)) {
+        inheritsFrom.get(parent.name)!.push(entity.name);
+      } else {
+        inheritsFrom.set(parent.name, [entity.name]);
+      }
+      parent = er.entities.find((e) => e.name === parent!.parentName);
+    }
+  }
+
+  return errors;
+};

--- a/src/ERDoc/linter/entity/checkEntityExtendsChild.ts
+++ b/src/ERDoc/linter/entity/checkEntityExtendsChild.ts
@@ -27,7 +27,7 @@ export const checkEntityExtendsChildEntity = (
 
     if (!entity.hasParent) continue;
     let parent = er.entities.find((e) => e.name === entity.parentName);
-    while (parent !== undefined && parent!.name !== entity.name) {
+    while (parent !== undefined && parent.name !== entity.name) {
       // parent can't be in my childs
       const myChilds = inheritsFrom.get(entity.name);
       if (myChilds !== undefined) {

--- a/src/ERDoc/linter/index.ts
+++ b/src/ERDoc/linter/index.ts
@@ -17,6 +17,7 @@ import { checkAggregationRelationshipNotExists } from "./aggregation/checkAggreg
 import { checkAggregationUsesSameRelationship } from "./aggregation/checkAggregationUsesSameRelationship";
 import { checkAggregationUsesEntityName } from "./aggregation/checkAggregationUsesEntityName";
 import { checkRelationshipParticipatingEntityNotExists } from "./relationship/checkRelationshipParticipatingEntityNotExists";
+import { checkEntityExtendsChildEntity } from "./entity/checkEntityExtendsChild";
 
 type checkErrorFunction = (er: ER) => SemanticError[];
 
@@ -25,6 +26,7 @@ const validators: checkErrorFunction[] = [
   checkEntityDuplicateAttribute,
   checkEntityNoKey,
   checkEntityExtendsNonExistentEntity,
+  checkEntityExtendsChildEntity,
 
   checkChildEntityHasKey,
 

--- a/src/ERDoc/parser/peggy/er-parser.pegjs
+++ b/src/ERDoc/parser/peggy/er-parser.pegjs
@@ -1,4 +1,14 @@
 {{
+  const KEYWORDS = [
+"entity",
+"extends",
+"key",
+"pkey",
+"relation",
+"aggregation",
+"depends on"
+  ]
+
   function getLocation(location_fun) {
     const location = location_fun();
     const { source, ...rest } = location;
@@ -222,7 +232,7 @@ aggregation = declareAggregation _ identifier:aggregationIdentifier _0 Lparen ag
 
 aggregationIdentifier "aggregation identifier" = validWord
 // TOKENS
-validWord = characters:[a-zA-Z0-9_áéíóúÁÉÍÓÚñÑ]+ {return characters.join('')}
+validWord = characters:([a-zA-Z0-9_áéíóúÁÉÍÓÚñÑ]+) ! {return KEYWORDS.some(kw => kw == characters.join('').toLowerCase())} {return characters.join('')}
 Lcurly = "{"
 Rcurly = "}"
 Lbracket = "["
@@ -232,12 +242,16 @@ Rparen = ")"
 
 declareEntity = "entity"i
 declareExtends = "extends"i
-_ "1 or more whitespaces" = [ \t\n]+
-_0 "0 or more whitespaces" = [ \t\n]*
 declareIsKey "key" = "key"
 declareIsPartialKey "partial key" = "pkey"
-
+declareRelationship = "relation"i
+declareAggregation = "aggregation"i
 dependsOn = "depends on"i
+
+_ "1 or more whitespaces" = [ \t\n]+
+_0 "0 or more whitespaces" = [ \t\n]*
+
+
 through = "through"i
 relationshipDependencyIdentifier "relationship identifier" = validWord
 entityIdentifier "entity identifier" = validWord
@@ -245,5 +259,3 @@ attributeIdentifier "attribute identifier" = validWord
 parentIdentifier "parent identifier" = validWord
 relationshipIdentifier "relationship identifier" = validWord
 
-declareRelationship = "relation"i
-declareAggregation = "aggregation"i

--- a/src/ERDoc/parser/peggy/generated.js
+++ b/src/ERDoc/parser/peggy/generated.js
@@ -5,6 +5,16 @@
 "use strict";
 
 
+  const KEYWORDS = [
+"entity",
+"extends",
+"key",
+"pkey",
+"relation",
+"aggregation",
+"depends on"
+  ]
+
   function getLocation(location_fun) {
     const location = location_fun();
     const { source, ...rest } = location;
@@ -197,10 +207,10 @@ function peg$parse(input, options) {
   var peg$c11 = "extends";
   var peg$c12 = "key";
   var peg$c13 = "pkey";
-  var peg$c14 = "depends on";
-  var peg$c15 = "through";
-  var peg$c16 = "relation";
-  var peg$c17 = "aggregation";
+  var peg$c14 = "relation";
+  var peg$c15 = "aggregation";
+  var peg$c16 = "depends on";
+  var peg$c17 = "through";
 
   var peg$r0 = /^[ \t]/;
   var peg$r1 = /^[0-9]/;
@@ -226,21 +236,21 @@ function peg$parse(input, options) {
   var peg$e15 = peg$literalExpectation(")", false);
   var peg$e16 = peg$literalExpectation("entity", true);
   var peg$e17 = peg$literalExpectation("extends", true);
-  var peg$e18 = peg$otherExpectation("1 or more whitespaces");
-  var peg$e19 = peg$classExpectation([" ", "\t", "\n"], false, false);
-  var peg$e20 = peg$otherExpectation("0 or more whitespaces");
-  var peg$e21 = peg$otherExpectation("key");
-  var peg$e22 = peg$literalExpectation("key", false);
-  var peg$e23 = peg$otherExpectation("partial key");
-  var peg$e24 = peg$literalExpectation("pkey", false);
-  var peg$e25 = peg$literalExpectation("depends on", true);
-  var peg$e26 = peg$literalExpectation("through", true);
-  var peg$e27 = peg$otherExpectation("relationship identifier");
-  var peg$e28 = peg$otherExpectation("entity identifier");
-  var peg$e29 = peg$otherExpectation("attribute identifier");
-  var peg$e30 = peg$otherExpectation("parent identifier");
-  var peg$e31 = peg$literalExpectation("relation", true);
-  var peg$e32 = peg$literalExpectation("aggregation", true);
+  var peg$e18 = peg$otherExpectation("key");
+  var peg$e19 = peg$literalExpectation("key", false);
+  var peg$e20 = peg$otherExpectation("partial key");
+  var peg$e21 = peg$literalExpectation("pkey", false);
+  var peg$e22 = peg$literalExpectation("relation", true);
+  var peg$e23 = peg$literalExpectation("aggregation", true);
+  var peg$e24 = peg$literalExpectation("depends on", true);
+  var peg$e25 = peg$otherExpectation("1 or more whitespaces");
+  var peg$e26 = peg$classExpectation([" ", "\t", "\n"], false, false);
+  var peg$e27 = peg$otherExpectation("0 or more whitespaces");
+  var peg$e28 = peg$literalExpectation("through", true);
+  var peg$e29 = peg$otherExpectation("relationship identifier");
+  var peg$e30 = peg$otherExpectation("entity identifier");
+  var peg$e31 = peg$otherExpectation("attribute identifier");
+  var peg$e32 = peg$otherExpectation("parent identifier");
 
   var peg$f0 = function() {return null};
   var peg$f1 = function(all) {
@@ -376,7 +386,8 @@ function peg$parse(input, options) {
     location: getLocation(location)
     }
 };
-  var peg$f46 = function(characters) {return characters.join('')};
+  var peg$f46 = function(characters) {return KEYWORDS.some(kw => kw == characters.join('').toLowerCase())};
+  var peg$f47 = function(characters) {return characters.join('')};
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -2152,10 +2163,24 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f46(s1);
+      peg$savedPos = peg$currPos;
+      s2 = peg$f46(s1);
+      if (s2) {
+        s2 = peg$FAILED;
+      } else {
+        s2 = undefined;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f47(s1);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-    s0 = s1;
 
     return s0;
   }
@@ -2272,6 +2297,88 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsedeclareIsKey() {
+    var s0, s1;
+
+    peg$silentFails++;
+    if (input.substr(peg$currPos, 3) === peg$c12) {
+      s0 = peg$c12;
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e19); }
+    }
+    peg$silentFails--;
+    if (s0 === peg$FAILED) {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e18); }
+    }
+
+    return s0;
+  }
+
+  function peg$parsedeclareIsPartialKey() {
+    var s0, s1;
+
+    peg$silentFails++;
+    if (input.substr(peg$currPos, 4) === peg$c13) {
+      s0 = peg$c13;
+      peg$currPos += 4;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e21); }
+    }
+    peg$silentFails--;
+    if (s0 === peg$FAILED) {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e20); }
+    }
+
+    return s0;
+  }
+
+  function peg$parsedeclareRelationship() {
+    var s0;
+
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c14) {
+      s0 = input.substr(peg$currPos, 8);
+      peg$currPos += 8;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e22); }
+    }
+
+    return s0;
+  }
+
+  function peg$parsedeclareAggregation() {
+    var s0;
+
+    if (input.substr(peg$currPos, 11).toLowerCase() === peg$c15) {
+      s0 = input.substr(peg$currPos, 11);
+      peg$currPos += 11;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e23); }
+    }
+
+    return s0;
+  }
+
+  function peg$parsedependsOn() {
+    var s0;
+
+    if (input.substr(peg$currPos, 10).toLowerCase() === peg$c16) {
+      s0 = input.substr(peg$currPos, 10);
+      peg$currPos += 10;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e24); }
+    }
+
+    return s0;
+  }
+
   function peg$parse_() {
     var s0, s1;
 
@@ -2282,7 +2389,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e19); }
+      if (peg$silentFails === 0) { peg$fail(peg$e26); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
@@ -2292,7 +2399,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e19); }
+          if (peg$silentFails === 0) { peg$fail(peg$e26); }
         }
       }
     } else {
@@ -2301,7 +2408,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e18); }
+      if (peg$silentFails === 0) { peg$fail(peg$e25); }
     }
 
     return s0;
@@ -2317,7 +2424,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e19); }
+      if (peg$silentFails === 0) { peg$fail(peg$e26); }
     }
     while (s1 !== peg$FAILED) {
       s0.push(s1);
@@ -2326,66 +2433,12 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e19); }
+        if (peg$silentFails === 0) { peg$fail(peg$e26); }
       }
     }
     peg$silentFails--;
     s1 = peg$FAILED;
-    if (peg$silentFails === 0) { peg$fail(peg$e20); }
-
-    return s0;
-  }
-
-  function peg$parsedeclareIsKey() {
-    var s0, s1;
-
-    peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c12) {
-      s0 = peg$c12;
-      peg$currPos += 3;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e22); }
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e21); }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedeclareIsPartialKey() {
-    var s0, s1;
-
-    peg$silentFails++;
-    if (input.substr(peg$currPos, 4) === peg$c13) {
-      s0 = peg$c13;
-      peg$currPos += 4;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e24); }
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e23); }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedependsOn() {
-    var s0;
-
-    if (input.substr(peg$currPos, 10).toLowerCase() === peg$c14) {
-      s0 = input.substr(peg$currPos, 10);
-      peg$currPos += 10;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e25); }
-    }
+    if (peg$silentFails === 0) { peg$fail(peg$e27); }
 
     return s0;
   }
@@ -2393,12 +2446,12 @@ function peg$parse(input, options) {
   function peg$parsethrough() {
     var s0;
 
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c15) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c17) {
       s0 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e26); }
+      if (peg$silentFails === 0) { peg$fail(peg$e28); }
     }
 
     return s0;
@@ -2412,7 +2465,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e27); }
+      if (peg$silentFails === 0) { peg$fail(peg$e29); }
     }
 
     return s0;
@@ -2426,7 +2479,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e28); }
+      if (peg$silentFails === 0) { peg$fail(peg$e30); }
     }
 
     return s0;
@@ -2440,7 +2493,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      if (peg$silentFails === 0) { peg$fail(peg$e31); }
     }
 
     return s0;
@@ -2454,7 +2507,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e30); }
+      if (peg$silentFails === 0) { peg$fail(peg$e32); }
     }
 
     return s0;
@@ -2468,35 +2521,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e27); }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedeclareRelationship() {
-    var s0;
-
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c16) {
-      s0 = input.substr(peg$currPos, 8);
-      peg$currPos += 8;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e31); }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedeclareAggregation() {
-    var s0;
-
-    if (input.substr(peg$currPos, 11).toLowerCase() === peg$c17) {
-      s0 = input.substr(peg$currPos, 11);
-      peg$currPos += 11;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      if (peg$silentFails === 0) { peg$fail(peg$e29); }
     }
 
     return s0;

--- a/src/ERDoc/types/linter/SemanticError.ts
+++ b/src/ERDoc/types/linter/SemanticError.ts
@@ -20,11 +20,11 @@ export type EntityHasNoKeyError = {
 };
 
 export type EntityExtendsChildEntityError = {
-    type: "ENTITY_EXTENDS_CHILD_ENTITY";
-    parentEntityName: string;
-    childEntityName: string;
-    location: TokenLocation;
-}
+  type: "ENTITY_EXTENDS_CHILD_ENTITY";
+  parentEntityName: string;
+  childEntityName: string;
+  location: TokenLocation;
+};
 
 export type EntityExtendsNonExistentEntityError = {
   type: "ENTITY_EXTENDS_NON_EXISTENT_ENTITY";

--- a/src/ERDoc/types/linter/SemanticError.ts
+++ b/src/ERDoc/types/linter/SemanticError.ts
@@ -19,6 +19,13 @@ export type EntityHasNoKeyError = {
   location: TokenLocation;
 };
 
+export type EntityExtendsChildEntityError = {
+    type: "ENTITY_EXTENDS_CHILD_ENTITY";
+    parentEntityName: string;
+    childEntityName: string;
+    location: TokenLocation;
+}
+
 export type EntityExtendsNonExistentEntityError = {
   type: "ENTITY_EXTENDS_NON_EXISTENT_ENTITY";
   entityName: string;
@@ -117,6 +124,7 @@ export type SemanticError =
   | EntityDuplicateAttributeError
   | EntityHasNoKeyError
   | EntityExtendsNonExistentEntityError
+  | EntityExtendsChildEntityError
   | ChildEntityHasKeyError
   | WeakEntityDependsOnNonExistentRelationshipError
   | WeakEntityNotInRelationshipError

--- a/test/ERDoc/linter/entity_duplicate_attribute.test.ts
+++ b/test/ERDoc/linter/entity_duplicate_attribute.test.ts
@@ -55,6 +55,11 @@ describe("Linter detects duplicate attributes in entities", () => {
     expect(errors[0].entityName).toBe("Ferrari");
     expect(errors[0].attributeName).toBe("Brand");
   });
+
+  it("returns when there is a circular inheritance", () => {
+    const errors = checkEntityDuplicateAttribute(ERWithCircularInheritance);
+    expect(errors).toHaveLength(0);
+  });
 });
 
 /*
@@ -919,6 +924,190 @@ const ERWithWrongSubclass2: ER = {
         end: {
           offset: 168,
           line: 14,
+          column: 2,
+        },
+      },
+    },
+  ],
+  relationships: [],
+  aggregations: [],
+};
+
+/*
+entity Dog extends Mammal {
+    breed
+}
+
+entity Mammal extends Animal {
+    hasHair
+}
+
+entity Animal extends Life {
+    age
+}
+
+entity Life extends Dog {
+    l_id key
+}
+*/
+const ERWithCircularInheritance: ER = {
+  entities: [
+    {
+      type: "entity",
+      name: "Dog",
+      attributes: [
+        {
+          name: "breed",
+          location: {
+            start: {
+              offset: 32,
+              line: 2,
+              column: 5,
+            },
+            end: {
+              offset: 37,
+              line: 2,
+              column: 10,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Mammal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 0,
+          line: 1,
+          column: 1,
+        },
+        end: {
+          offset: 39,
+          line: 3,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Mammal",
+      attributes: [
+        {
+          name: "hasHair",
+          location: {
+            start: {
+              offset: 73,
+              line: 6,
+              column: 2,
+            },
+            end: {
+              offset: 80,
+              line: 6,
+              column: 9,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Animal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 41,
+          line: 5,
+          column: 1,
+        },
+        end: {
+          offset: 82,
+          line: 7,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Animal",
+      attributes: [
+        {
+          name: "age",
+          location: {
+            start: {
+              offset: 114,
+              line: 10,
+              column: 2,
+            },
+            end: {
+              offset: 117,
+              line: 10,
+              column: 5,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Life",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 84,
+          line: 9,
+          column: 1,
+        },
+        end: {
+          offset: 119,
+          line: 11,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Life",
+      attributes: [
+        {
+          name: "l_id",
+          location: {
+            start: {
+              offset: 148,
+              line: 14,
+              column: 2,
+            },
+            end: {
+              offset: 156,
+              line: 14,
+              column: 10,
+            },
+          },
+          isKey: true,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Dog",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 121,
+          line: 13,
+          column: 1,
+        },
+        end: {
+          offset: 158,
+          line: 15,
           column: 2,
         },
       },

--- a/test/ERDoc/linter/entity_extends_child_entity.test.ts
+++ b/test/ERDoc/linter/entity_extends_child_entity.test.ts
@@ -1,0 +1,489 @@
+import { checkEntityExtendsChildEntity } from "../../../src/ERDoc/linter/entity/checkEntityExtendsChild";
+import { ER } from "../../../src/ERDoc/types/parser/ER";
+
+describe("Linter detects when a child entity extends a child entity", () => {
+  it("should return an error when an entity extends a child entity", () => {
+    const errors = checkEntityExtendsChildEntity(wrongER);
+    expect(errors.length).toBe(1);
+    expect(errors[0].type).toBe("ENTITY_EXTENDS_CHILD_ENTITY");
+    expect(errors[0].parentEntityName).toBe("Animal");
+    expect(errors[0].childEntityName).toBe("Dog");
+  });
+
+  it("should return an error when an entity extends a child from multiple levels of inheritance", () => {
+    const errors = checkEntityExtendsChildEntity(wrongERmultipleInheritance);
+    expect(errors.length).toBe(1);
+    expect(errors[0].type).toBe("ENTITY_EXTENDS_CHILD_ENTITY");
+    expect(errors[0].parentEntityName).toBe("Life");
+    expect(errors[0].childEntityName).toBe("Dog");
+  });
+
+  it("should return an empty array when no entity extends a child entity", () => {
+    const errors = checkEntityExtendsChildEntity(correctER);
+    expect(errors.length).toBe(0);
+  });
+});
+
+/*
+entity Dog extends Animal {
+    breed
+}
+
+entity Animal extends Dog {
+	a_id key
+}
+ */
+const wrongER: ER = {
+  entities: [
+    {
+      type: "entity",
+      name: "Dog",
+      attributes: [
+        {
+          name: "breed",
+          location: {
+            start: {
+              offset: 32,
+              line: 2,
+              column: 5,
+            },
+            end: {
+              offset: 37,
+              line: 2,
+              column: 10,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Animal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 0,
+          line: 1,
+          column: 1,
+        },
+        end: {
+          offset: 39,
+          line: 3,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Animal",
+      attributes: [
+        {
+          name: "a_id",
+          location: {
+            start: {
+              offset: 70,
+              line: 6,
+              column: 2,
+            },
+            end: {
+              offset: 78,
+              line: 6,
+              column: 10,
+            },
+          },
+          isKey: true,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Dog",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 41,
+          line: 5,
+          column: 1,
+        },
+        end: {
+          offset: 80,
+          line: 7,
+          column: 2,
+        },
+      },
+    },
+  ],
+  relationships: [],
+  aggregations: [],
+};
+
+/*
+entity Dog extends Mammal {
+    breed
+}
+
+entity Mammal extends Animal {
+	hasHair
+}
+
+entity Animal extends Life {
+	age
+}
+
+entity Life extends Dog {
+	l_id key
+}
+*/
+const wrongERmultipleInheritance: ER = {
+  entities: [
+    {
+      type: "entity",
+      name: "Dog",
+      attributes: [
+        {
+          name: "breed",
+          location: {
+            start: {
+              offset: 32,
+              line: 2,
+              column: 5,
+            },
+            end: {
+              offset: 37,
+              line: 2,
+              column: 10,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Mammal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 0,
+          line: 1,
+          column: 1,
+        },
+        end: {
+          offset: 39,
+          line: 3,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Mammal",
+      attributes: [
+        {
+          name: "hasHair",
+          location: {
+            start: {
+              offset: 73,
+              line: 6,
+              column: 2,
+            },
+            end: {
+              offset: 80,
+              line: 6,
+              column: 9,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Animal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 41,
+          line: 5,
+          column: 1,
+        },
+        end: {
+          offset: 82,
+          line: 7,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Animal",
+      attributes: [
+        {
+          name: "age",
+          location: {
+            start: {
+              offset: 114,
+              line: 10,
+              column: 2,
+            },
+            end: {
+              offset: 117,
+              line: 10,
+              column: 5,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Life",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 84,
+          line: 9,
+          column: 1,
+        },
+        end: {
+          offset: 119,
+          line: 11,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Life",
+      attributes: [
+        {
+          name: "l_id",
+          location: {
+            start: {
+              offset: 148,
+              line: 14,
+              column: 2,
+            },
+            end: {
+              offset: 156,
+              line: 14,
+              column: 10,
+            },
+          },
+          isKey: true,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Dog",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 121,
+          line: 13,
+          column: 1,
+        },
+        end: {
+          offset: 158,
+          line: 15,
+          column: 2,
+        },
+      },
+    },
+  ],
+  relationships: [],
+  aggregations: [],
+};
+
+/*
+entity Dog extends Mammal {
+    breed
+}
+
+entity Mammal extends Animal {
+	hasHair
+}
+
+entity Animal extends Life {
+	age
+}
+
+entity Life {
+	l_id key
+}
+*/
+const correctER: ER = {
+  entities: [
+    {
+      type: "entity",
+      name: "Dog",
+      attributes: [
+        {
+          name: "breed",
+          location: {
+            start: {
+              offset: 32,
+              line: 2,
+              column: 5,
+            },
+            end: {
+              offset: 37,
+              line: 2,
+              column: 10,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Mammal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 0,
+          line: 1,
+          column: 1,
+        },
+        end: {
+          offset: 39,
+          line: 3,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Mammal",
+      attributes: [
+        {
+          name: "hasHair",
+          location: {
+            start: {
+              offset: 73,
+              line: 6,
+              column: 2,
+            },
+            end: {
+              offset: 80,
+              line: 6,
+              column: 9,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Animal",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 41,
+          line: 5,
+          column: 1,
+        },
+        end: {
+          offset: 82,
+          line: 7,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Animal",
+      attributes: [
+        {
+          name: "age",
+          location: {
+            start: {
+              offset: 114,
+              line: 10,
+              column: 2,
+            },
+            end: {
+              offset: 117,
+              line: 10,
+              column: 5,
+            },
+          },
+          isKey: false,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: true,
+      parentName: "Life",
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 84,
+          line: 9,
+          column: 1,
+        },
+        end: {
+          offset: 119,
+          line: 11,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: "entity",
+      name: "Life",
+      attributes: [
+        {
+          name: "l_id",
+          location: {
+            start: {
+              offset: 136,
+              line: 14,
+              column: 2,
+            },
+            end: {
+              offset: 144,
+              line: 14,
+              column: 10,
+            },
+          },
+          isKey: true,
+          isComposite: false,
+          childAttributesNames: null,
+        },
+      ],
+      hasParent: false,
+      parentName: null,
+      hasDependencies: false,
+      dependsOn: null,
+      location: {
+        start: {
+          offset: 121,
+          line: 13,
+          column: 1,
+        },
+        end: {
+          offset: 146,
+          line: 15,
+          column: 2,
+        },
+      },
+    },
+  ],
+  relationships: [],
+  aggregations: [],
+};


### PR DESCRIPTION
- Adds a new linting rule that checks if an entity extends a child
- fixes infinite loop in entity duplicate attributes rule (was related to the new rule).
- now the parser doesn't allows reserved keywords as identifiers.