### PR TITLE
feat:examples and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
         "react-resizable-panels": "^0.0.55",
-        "reactflow": "^11.8.3"
+        "reactflow": "^11.8.3",
+        "webcola": "^3.4.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.2",
@@ -4726,6 +4727,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
@@ -4740,6 +4746,14 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
       }
     },
     "node_modules/d3-timer": {
@@ -9802,6 +9816,41 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
+      }
+    },
+    "node_modules/webcola/node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "node_modules/webcola/node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/webcola/node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
+    },
+    "node_modules/webcola/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
     "react-resizable-panels": "^0.0.55",
-    "reactflow": "^11.8.3"
+    "reactflow": "^11.8.3",
+    "webcola": "^3.4.0"
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,7 +2,6 @@
 import { Grid, GridItem } from "@chakra-ui/react";
 import Body from "../components/Body";
 import Header from "../components/Header";
-import { colors } from "../util/colors";
 
 const Page = () => {
   return (
@@ -20,10 +19,9 @@ const Page = () => {
         textColor={"white"}
         display={"flex"}
         justifyContent={"between"}
-        paddingY={2}
         paddingX={4}
         flex={"wrap"}
-        backgroundColor={colors.textEditorBackground}
+        backgroundColor={"#232730"}
         borderBottom={"1px"}
         borderBottomColor={"rgb(248 250 252 / 0.16)"}
         area="header"

--- a/src/app/api/examples/[example]/route.ts
+++ b/src/app/api/examples/[example]/route.ts
@@ -1,0 +1,22 @@
+import { EXAMPLES } from "../../../util/ErdocExamples";
+
+//eslint-disable-next-line  @typescript-eslint/require-await
+export async function GET(
+  _request: Request,
+  { params }: { params: { example: string } },
+) {
+  const exampleName = params.example;
+  if (exampleName in EXAMPLES) {
+    return new Response(JSON.stringify({ example: EXAMPLES[exampleName] }), {
+      headers: { "content-type": "application/json" },
+    });
+  } else {
+    return new Response(
+      JSON.stringify({ error: `Example ${exampleName} not found` }),
+      {
+        headers: { "content-type": "application/json" },
+        status: 404,
+      },
+    );
+  }
+}

--- a/src/app/components/CodeEditor/CodeEditor.tsx
+++ b/src/app/components/CodeEditor/CodeEditor.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef, useState } from "react";
 import { getERDoc } from "../../../ERDoc";
 import { ER } from "../../../ERDoc/types/parser/ER";
 import { ErrorMessage, MarkerSeverity } from "../../types/CodeEditor";
-import { EXAMPLES } from "../../util/ErdocExamples";
 import { colors } from "../../util/colors";
 import getErrorMessage from "../../util/errorMessages";
 import ErrorTable from "./ErrorTable";
@@ -78,8 +77,6 @@ const erdocTokenizer: languages.IMonarchLanguage = {
   },
 };
 
-const INITIAL_CONTENT = EXAMPLES["bank"];
-
 const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
   const [selectedExample, setSelectedExample] = useState<string | null>(null);
 
@@ -141,7 +138,7 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
 
   const handleEditorMount: OnMount = (editor, m) => {
     editorRef.current = editor;
-    handleEditorContent(INITIAL_CONTENT);
+    handleEditorContent(DEFAULT_CONTENT);
     // mount erdoc language
     m.languages.register({ id: "erdoc" });
     m.languages.setMonarchTokensProvider("erdoc", erdocTokenizer);
@@ -151,7 +148,7 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
       m.editor.defineTheme(themeName, theme);
     }
     m.editor.setTheme(DEFAULT_THEME);
-    editor.setValue(INITIAL_CONTENT);
+    editor.setValue(DEFAULT_CONTENT);
   };
 
   useEffect(() => {
@@ -224,3 +221,47 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
 };
 
 export default CodeEditor;
+
+const DEFAULT_CONTENT = `entity bank {
+    code key
+    name
+    addr
+}
+
+entity bank_branch depends on has_branches {
+    addr
+    branch_no pkey
+}
+
+relation has_branches(bank 1!, bank_branch N!)
+
+entity account {
+    acct_no key
+    balance
+    type
+}
+
+entity loan {
+    loan_no key
+    amount
+    type
+}
+
+relation accts(Bank_With_Branches 1, account N!)
+relation loans(Bank_With_Branches 1, loan N!)
+
+entity customer {
+    ssn key
+    name
+    addr
+    phone
+}
+
+entity premium_customer extends customer {
+    discount
+}
+
+relation a_c(customer N, account M!)
+relation l_c(customer N, loan M!)
+
+aggregation Bank_With_Branches(has_branches)`;

--- a/src/app/components/CodeEditor/CodeEditor.tsx
+++ b/src/app/components/CodeEditor/CodeEditor.tsx
@@ -8,8 +8,9 @@ import { ER } from "../../../ERDoc/types/parser/ER";
 import { ErrorMessage, MarkerSeverity } from "../../types/CodeEditor";
 import { colors } from "../../util/colors";
 import getErrorMessage from "../../util/errorMessages";
-import ErrorTable from "./ErrorTable";
+import { EditorHeader } from "./EditorHeader";
 import ExamplesTable from "./ExamplesTable";
+import ErrorTable from "./ErrorTable";
 
 type ErrorReportingEditorProps = {
   onErDocChange: (er: ER) => void;
@@ -174,6 +175,7 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
       flexDir={"column"}
       overflow={"hidden"}
     >
+      <EditorHeader editorRef={editorRef} />
       <Box
         resize="none"
         pt={1}
@@ -183,23 +185,20 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
         overflow="hidden"
         bg={colors.textEditorBackground}
       >
-        {
-          <Editor
-            height={"100%"}
-            // value={initialContent}
-            onChange={(content, _) => handleEditorContent(content!)}
-            onMount={handleEditorMount}
-            loading={<Spinner color="white" />}
-            language="erdoc"
-            options={{
-              autoClosingBrackets: "always",
-              scrollBeyondLastLine: false,
-              minimap: {
-                enabled: false,
-              },
-            }}
-          />
-        }
+        <Editor
+          height={"100%"}
+          onChange={(content, _evt) => handleEditorContent(content!)}
+          onMount={handleEditorMount}
+          loading={<Spinner color="white" />}
+          language="erdoc"
+          options={{
+            autoClosingBrackets: "always",
+            scrollBeyondLastLine: false,
+            minimap: {
+              enabled: false,
+            },
+          }}
+        />
       </Box>
 
       <Box

--- a/src/app/components/CodeEditor/EditorHeader.tsx
+++ b/src/app/components/CodeEditor/EditorHeader.tsx
@@ -1,0 +1,89 @@
+import { Box, IconButton } from "@chakra-ui/react";
+import { editor } from "monaco-types";
+import { MutableRefObject, ReactElement, useState } from "react";
+import { colors } from "../../util/colors";
+import { BiSolidCopyAlt } from "react-icons/bi";
+import { FaRedo, FaUndo } from "react-icons/fa";
+import { AiOutlineCheck } from "react-icons/ai";
+import { useTranslations } from "next-intl";
+
+export const EditorHeader = ({
+  editorRef,
+}: {
+  editorRef: MutableRefObject<editor.IStandaloneCodeEditor | null>;
+}) => {
+  const t = useTranslations("home.codeEditor.editorHeader");
+
+  return (
+    <Box
+      height={"3.6%"}
+      bg={colors.textEditorBackground}
+      borderBottom={"1px"}
+      borderBottomColor={"rgb(248 250 252 / 0.16)"}
+      className=" flex w-full flex-row items-center justify-end"
+    >
+      <div className="flex">
+        <EditorButton
+          icon={<BiSolidCopyAlt fill="#fff" />}
+          label={t("copy")}
+          useClickedAnimation={true}
+          onClick={() => {
+            const content = editorRef.current?.getValue();
+            if (content) void navigator.clipboard.writeText(content);
+          }}
+        />
+
+        <EditorButton
+          icon={<FaUndo fill="#fff" />}
+          label={t("undo")}
+          onClick={() => editorRef.current?.trigger("undoButton", "undo", null)}
+        />
+
+        <EditorButton
+          icon={<FaRedo fill="#fff" />}
+          label={t("redo")}
+          onClick={() => editorRef.current?.trigger("undoButton", "redo", null)}
+        />
+      </div>
+    </Box>
+  );
+};
+
+const EditorButton = ({
+  icon,
+  onClick,
+  label,
+  useClickedAnimation = false,
+}: {
+  useClickedAnimation?: boolean;
+  icon: ReactElement;
+  onClick: () => void;
+  label: string;
+}) => {
+  const [clicked, setClicked] = useState(false);
+  const onClickHandler = () => {
+    onClick();
+    if (useClickedAnimation) {
+      setClicked(true);
+      setTimeout(() => setClicked(false), 300);
+    }
+  };
+
+  return (
+    <IconButton
+      borderRadius={"2xl"}
+      bg={colors.textEditorBackground}
+      _hover={{ bg: "#2e3136" }}
+      _active={{ bg: "#3f4651", borderWidth: "1px", borderColor: "green" }}
+      style={{
+        borderWidth: clicked ? "1px" : "0px",
+        borderColor: clicked ? "green" : "transparent",
+      }}
+      h={"25px"}
+      aria-label={label}
+      title={label}
+      icon={clicked ? <AiOutlineCheck fill={"#4ade80"} /> : icon}
+      onClick={onClickHandler}
+    />
+  );
+};

--- a/src/app/components/CodeEditor/ExamplesTable.tsx
+++ b/src/app/components/CodeEditor/ExamplesTable.tsx
@@ -3,7 +3,7 @@ import { List } from "@chakra-ui/layout";
 import { Button } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { EXAMPLES } from "../../util/ErdocExamples";
+import { EXAMPLE_NAMES } from "../../util/ErdocExamples";
 
 interface ExamplesTableProps {
   onExampleClick: (newExample: string) => void;
@@ -12,6 +12,36 @@ interface ExamplesTableProps {
 const ExamplesTable = ({ onExampleClick }: ExamplesTableProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const t = useTranslations("home.examples");
+
+  const fetchExample = async (exampleName: string) => {
+    const res = await fetch(`/api/examples/${exampleName}`);
+    // if res is 404, then the example doesn't exist
+    if (res.status === 404) {
+      return null;
+    } else {
+      const data: { example: string } = await (res.json() as Promise<{
+        example: string;
+      }>);
+      return data.example;
+    }
+  };
+
+  const onExampleClickHandler = (exampleName: string) => {
+    const exampleKey = `example ${exampleName}`;
+    const storedExample = localStorage.getItem(exampleKey);
+    if (storedExample !== null) {
+      onExampleClick(storedExample);
+      return;
+    }
+    fetchExample(exampleName)
+      .then((example) => {
+        if (example) {
+          localStorage.setItem(`example ${exampleName}`, example);
+          onExampleClick(example);
+        }
+      })
+      .catch((err) => console.error(err));
+  };
 
   return (
     <div className="mb-4 h-full w-full text-white">
@@ -27,13 +57,11 @@ const ExamplesTable = ({ onExampleClick }: ExamplesTableProps) => {
       {isOpen && (
         <div className="h-full overflow-auto rounded-b-md border-b border-l border-r border-slate-50/[0.16] bg-primary p-2 pb-10">
           <List overflow={"auto"} pb={"5"}>
-            {Object.keys(EXAMPLES).map((exampleName) => (
+            {EXAMPLE_NAMES.map((exampleName) => (
               <Button
                 key={exampleName}
                 className="mr-1 bg-blue-500 text-white hover:bg-blue-600"
-                onClick={() => {
-                  onExampleClick(EXAMPLES[exampleName]);
-                }}
+                onClick={() => onExampleClickHandler(exampleName)}
               >
                 {t(exampleName)}
               </Button>

--- a/src/app/components/ErDiagram/ErDiagram.tsx
+++ b/src/app/components/ErDiagram/ErDiagram.tsx
@@ -24,6 +24,7 @@ import {
   getLayoutedElements,
   useLayoutedElements,
 } from "./useLayoutedElements";
+import { Spinner } from "@chakra-ui/react";
 
 type ErDiagramProps = {
   erDoc: ER;
@@ -61,6 +62,7 @@ const ErDiagram = ({
   const { layoutElements } = useLayoutedElements();
   const { d3LayoutElements } = useD3LayoutedElements();
   const { ColaLayoutElements } = useColaLayoutedElements();
+  const [isLayouting, setIsLayouting] = useState(false);
 
   const isFirstRenderRef = useRef<boolean | null>(true);
   const nodesInitialized = useNodesInitialized();
@@ -141,6 +143,10 @@ const ErDiagram = ({
     }
   }, [nodes, edges]);
 
+  useEffect(() => {
+    console.log("isLayouting", isLayouting);
+  }, [isLayouting]);
+
   return (
     <ReactFlow
       nodes={nodes}
@@ -169,10 +175,11 @@ const ErDiagram = ({
         <br />
         <button
           onClick={() => {
+            setIsLayouting(true);
             void layoutElements({
               "elk.algorithm": "org.eclipse.elk.stress",
               "elk.stress.desiredEdgeLength": "110",
-            });
+            }).then(() => setIsLayouting(false));
           }}
         >
           ELK stress layout
@@ -191,6 +198,7 @@ const ErDiagram = ({
         <br />
         <button
           onClick={() => {
+            setIsLayouting(true);
             void layoutElements({
               "elk.algorithm": "org.eclipse.elk.force",
               // "elk.force.model": "EADES",
@@ -198,20 +206,44 @@ const ErDiagram = ({
               "elk.force.temperature": "0.05",
               "elk.spacing.nodeNode": "4",
               "elk.force.iterations": "1500",
-            });
+            }).then(() => setIsLayouting(false));
           }}
         >
           ELK 5K force layout
         </button>
 
         <br />
-        <button onClick={d3LayoutElements}>d3-force Layout</button>
+        <button
+          onClick={() => {
+            setIsLayouting(true);
+            d3LayoutElements();
+            setIsLayouting(false);
+          }}
+        >
+          d3-force Layout
+        </button>
 
         <br />
-        <button onClick={ColaLayoutElements}>Cola Layout</button>
+        <button
+          onClick={() => {
+            setIsLayouting(true);
+            // HACK: wrap in promise to allow state to update
+            void new Promise((resolve) => setTimeout(resolve, 1))
+              .then(() => {
+                ColaLayoutElements();
+              })
+              .then(() => setIsLayouting(false));
+          }}
+        >
+          Cola Layout
+        </button>
       </Panel>
 
       <Panel position="top-left">
+        {isLayouting && <Spinner color="black" />}
+      </Panel>
+
+      <Panel position="bottom-right">
         <NotationPicker
           initialNotation={notation}
           className=""

--- a/src/app/components/ErDiagram/ErDiagram.tsx
+++ b/src/app/components/ErDiagram/ErDiagram.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
+  Background,
+  BackgroundVariant,
   Node,
   Panel,
   ReactFlowProvider,
@@ -17,6 +19,7 @@ import { NotationPicker } from "./NotationPicker";
 import ArrowNotation from "./notations/ArrowNotation/ArrowNotation";
 import ErNotation from "./notations/DefaultNotation";
 import { useD3LayoutedElements } from "./useD3LayoutedElements";
+import { useColaLayoutedElements } from "./useColaLayoutedElements";
 import {
   getLayoutedElements,
   useLayoutedElements,
@@ -56,7 +59,8 @@ const ErDiagram = ({
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const { layoutElements } = useLayoutedElements();
-  const { D3LayoutElements } = useD3LayoutedElements();
+  const { d3LayoutElements } = useD3LayoutedElements();
+  const { ColaLayoutElements } = useColaLayoutedElements();
 
   const isFirstRenderRef = useRef<boolean | null>(true);
   const nodesInitialized = useNodesInitialized();
@@ -147,7 +151,19 @@ const ErDiagram = ({
       edgeTypes={erEdgeTypes}
       proOptions={{ hideAttribution: true }}
     >
-      {/* <Background variant={BackgroundVariant.Cross} /> */}
+      <Background
+        id="1"
+        gap={10}
+        color="#f1f1f1"
+        variant={BackgroundVariant.Lines}
+      />
+      <Background
+        id="2"
+        gap={100}
+        offset={1}
+        color="#e3e1e1"
+        variant={BackgroundVariant.Lines}
+      />
 
       <Panel position="top-right">
         <br />
@@ -161,8 +177,7 @@ const ErDiagram = ({
         >
           ELK stress layout
         </button>
-        <br />
-        <button
+        {/* <button
           onClick={() => {
             void layoutElements({
               "elk.algorithm": "org.eclipse.elk.radial",
@@ -171,7 +186,7 @@ const ErDiagram = ({
           }}
         >
           ELK radial layout
-        </button>
+        </button> */}
 
         <br />
         <button
@@ -186,11 +201,14 @@ const ErDiagram = ({
             });
           }}
         >
-          ELK force layout
+          ELK 5K force layout
         </button>
 
         <br />
-        <button onClick={D3LayoutElements}>d3-force Layout</button>
+        <button onClick={d3LayoutElements}>d3-force Layout</button>
+
+        <br />
+        <button onClick={ColaLayoutElements}>Cola Layout</button>
       </Panel>
 
       <Panel position="top-left">

--- a/src/app/components/ErDiagram/ErDiagram.tsx
+++ b/src/app/components/ErDiagram/ErDiagram.tsx
@@ -25,6 +25,7 @@ import {
   getLayoutedElements,
   useLayoutedElements,
 } from "./useLayoutedElements";
+import { useAlignmentGuide } from "./useAlignmentGuide";
 
 type ErDiagramProps = {
   erDoc: ER;
@@ -71,6 +72,7 @@ const ErDiagram = ({
   const erNodeTypes = useMemo(() => notation.nodeTypes, [notation]);
   const erEdgeTypes = useMemo(() => notation.edgeTypes, [notation]);
   const erEdgeNotation = useMemo(() => notation.edgeMarkers, [notation]);
+  const { onNodeDrag, onNodeDragStart, onNodeDragStop } = useAlignmentGuide();
 
   useEffect(() => {
     if (erDoc === null) return;
@@ -163,6 +165,9 @@ const ErDiagram = ({
       edges={edges}
       onEdgesChange={onEdgesChange}
       edgeTypes={erEdgeTypes}
+      onNodeDrag={onNodeDrag}
+      onNodeDragStart={onNodeDragStart}
+      onNodeDragStop={onNodeDragStop}
       proOptions={{ hideAttribution: true }}
     >
       <Background

--- a/src/app/components/ErDiagram/NotationPicker.tsx
+++ b/src/app/components/ErDiagram/NotationPicker.tsx
@@ -38,6 +38,7 @@ export const NotationPicker = ({
         as={Button}
         rightIcon={<ChevronDownIcon />}
         border={"1px solid #eee"}
+        className="bg-[#fff]"
         shadow={"sm"}
       >
         {t("notationButton")}

--- a/src/app/components/ErDiagram/useAlignmentGuide.tsx
+++ b/src/app/components/ErDiagram/useAlignmentGuide.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useRef, useState, useEffect } from "react";
+import { Edge, Node, NodeDragHandler, useReactFlow } from "reactflow";
+
+const EPSILON = 0.4;
+
+// calculates the center point of the node from position and dimensions
+const nodeCenter = (node: Node) => ({
+  centerX: node.position.x + node.width! / 2,
+  centerY: node.position.y + node.height! / 2,
+});
+
+// removes all alignment-guide edges from the list of edges
+const removeGuideEdges = (edges: Edge[]) =>
+  edges.filter((e) => !e.id.startsWith("ALIGN"));
+
+// finds all nodes with their center aligned with the given x or y coordinate
+const findAlignedNodes = (
+  x: number,
+  y: number,
+  nodes: Node[],
+): ["x" | "y", Node][] => {
+  const alignedNodes: ["x" | "y", Node][] = [];
+
+  for (const node of nodes) {
+    const { centerX, centerY } = nodeCenter(node);
+    if (Math.abs(x - centerX) < EPSILON) alignedNodes.push(["x", node]);
+    else if (Math.abs(y - centerY) < EPSILON) alignedNodes.push(["y", node]);
+  }
+
+  alignedNodes.forEach(([alignDir, n]) => {
+    if (alignDir === "x") {
+      console.log(Math.abs(x - nodeCenter(n).centerX));
+    } else {
+      console.log(Math.abs(y - nodeCenter(n).centerY));
+    }
+  });
+
+  return alignedNodes;
+};
+
+export const useAlignmentGuide = () => {
+  const { getNodes, setEdges } = useReactFlow();
+  const nodes = getNodes();
+
+  // this ref stores the current dragged node
+  const dragRef = useRef<Node | null>(null);
+
+  const [alignedNodes, setAlignedNodes] = useState<Node[]>([]);
+
+  const onNodeDragStart: NodeDragHandler = useCallback((_evt, node) => {
+    dragRef.current = node;
+  }, []);
+
+  const onNodeDrag: NodeDragHandler = useCallback((_evt, node) => {
+    let { centerX, centerY } = nodeCenter(node);
+
+    if (node.parentNode) {
+      const parent = nodes.find((p) => p.id === node.parentNode);
+      if (parent) {
+        centerX += parent.position.x;
+        centerY += parent.position.y;
+      }
+    }
+
+    const absolutePositionNodes = nodes.map((n) => {
+      const pos = { x: n.position.x, y: n.position.y };
+      if (n.parentNode) {
+        const parent = nodes.find((p) => p.id === n.parentNode);
+        if (parent) {
+          pos.x += parent.position.x;
+          pos.y += parent.position.y;
+        }
+      }
+      return { ...n, position: pos };
+    });
+
+    const alignedNodes = findAlignedNodes(
+      centerX,
+      centerY,
+      absolutePositionNodes,
+    );
+
+    const alignmentGuideEdges = alignedNodes.map(([alignDir, n]) => {
+      let sourceHandle = "l";
+      let targetHandle = "r";
+
+      if (alignDir === "y") {
+        if (centerX < n.position.x) {
+          sourceHandle = "l";
+          targetHandle = "r";
+        }
+      } else if (alignDir === "x") {
+        if (centerY < n.position.y) {
+          sourceHandle = "b";
+          targetHandle = "t";
+        } else {
+          sourceHandle = "t";
+          targetHandle = "b";
+        }
+      }
+
+      return {
+        id: `ALIGN: ${node.id}-${n.id} ${Math.random()}`,
+        source: node.id,
+        target: n.id,
+        sourceHandle,
+        targetHandle,
+        style: { stroke: "red", zIndex: 1000 },
+        type: "straight",
+      } as Edge;
+    });
+
+    setEdges((edges) => {
+      // remove old alignment guides
+      const noGuidesEdges = removeGuideEdges(edges);
+      return [...noGuidesEdges, ...alignmentGuideEdges];
+    });
+
+    setAlignedNodes(alignedNodes.map(([_alignDir, n]) => n));
+  }, []);
+
+  const onNodeDragStop: NodeDragHandler = useCallback((_evt, _node) => {
+    setEdges((edges) => removeGuideEdges(edges));
+    dragRef.current = null;
+    setAlignedNodes([]);
+  }, []);
+
+  useEffect(() => {
+    // console.log(alignedNodes);
+    // whenever the target changes, we swap the colors temporarily
+    // this is just a placeholder, implement your own logic here
+    // if (target) {
+    //   console.log("#############");
+    //   console.log("target:", target.data.erId);
+    //   console.log("target pos:", target?.position);
+    //   console.log("being dragged pos:", dragRef.current?.position);
+    // }
+    // if (alignedNodes.length > 0) {
+    //   for (const node of alignedNodes) {
+    //     console.log(node.data.erId);
+    //   }
+    //   console.log("##########");
+    // }
+  }, [alignedNodes]);
+
+  return { onNodeDragStart, onNodeDrag, onNodeDragStop };
+};

--- a/src/app/components/ErDiagram/useAlignmentGuide.tsx
+++ b/src/app/components/ErDiagram/useAlignmentGuide.tsx
@@ -1,13 +1,15 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef } from "react";
 import { Edge, Node, NodeDragHandler, useReactFlow } from "reactflow";
 
 const EPSILON = 0.4;
 
 // calculates the center point of the node from position and dimensions
-const nodeCenter = (node: Node) => ({
-  centerX: node.position.x + node.width! / 2,
-  centerY: node.position.y + node.height! / 2,
-});
+const nodeCenter = (node: Node) => {
+  return {
+    centerX: node.position.x + node.width! / 2,
+    centerY: node.position.y + node.height! / 2,
+  };
+};
 
 // removes all alignment-guide edges from the list of edges
 const removeGuideEdges = (edges: Edge[]) =>
@@ -37,13 +39,11 @@ export const useAlignmentGuide = () => {
   // this ref stores the current dragged node
   const dragRef = useRef<Node | null>(null);
 
-  const [alignedNodes, setAlignedNodes] = useState<Node[]>([]);
-
-  const onNodeDragStart: NodeDragHandler = (_evt, node) => {
+  const onNodeDragStart: NodeDragHandler = (evt, node) => {
     dragRef.current = node;
   };
 
-  const onNodeDrag: NodeDragHandler = (_evt, node) => {
+  const onNodeDrag: NodeDragHandler = (evt, node) => {
     let { centerX, centerY } = nodeCenter(node);
 
     if (node.parentNode) {
@@ -97,43 +97,24 @@ export const useAlignmentGuide = () => {
         target: n.id,
         sourceHandle,
         targetHandle,
-        style: { stroke: "red", zIndex: 1000 },
+        style: { stroke: "red" },
         type: "straight",
+        animated: true,
       } as Edge;
     });
 
     setEdges((edges) => {
       // remove old alignment guides
       const noGuidesEdges = removeGuideEdges(edges);
+      // add the new alignment guides
       return [...noGuidesEdges, ...alignmentGuideEdges];
     });
-
-    setAlignedNodes(alignedNodes.map(([_alignDir, n]) => n));
   };
 
   const onNodeDragStop: NodeDragHandler = (_evt, _node) => {
     setEdges((edges) => removeGuideEdges(edges));
     dragRef.current = null;
-    setAlignedNodes([]);
   };
-
-  useEffect(() => {
-    // console.log(alignedNodes);
-    // whenever the target changes, we swap the colors temporarily
-    // this is just a placeholder, implement your own logic here
-    // if (target) {
-    //   console.log("#############");
-    //   console.log("target:", target.data.erId);
-    //   console.log("target pos:", target?.position);
-    //   console.log("being dragged pos:", dragRef.current?.position);
-    // }
-    // if (alignedNodes.length > 0) {
-    //   for (const node of alignedNodes) {
-    //     console.log(node.data.erId);
-    //   }
-    //   console.log("##########");
-    // }
-  }, [alignedNodes]);
 
   return { onNodeDragStart, onNodeDrag, onNodeDragStop };
 };

--- a/src/app/components/ErDiagram/useAlignmentGuide.tsx
+++ b/src/app/components/ErDiagram/useAlignmentGuide.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import { Edge, Node, NodeDragHandler, useReactFlow } from "reactflow";
 
 const EPSILON = 0.4;
@@ -27,14 +27,6 @@ const findAlignedNodes = (
     else if (Math.abs(y - centerY) < EPSILON) alignedNodes.push(["y", node]);
   }
 
-  alignedNodes.forEach(([alignDir, n]) => {
-    if (alignDir === "x") {
-      console.log(Math.abs(x - nodeCenter(n).centerX));
-    } else {
-      console.log(Math.abs(y - nodeCenter(n).centerY));
-    }
-  });
-
   return alignedNodes;
 };
 
@@ -47,11 +39,11 @@ export const useAlignmentGuide = () => {
 
   const [alignedNodes, setAlignedNodes] = useState<Node[]>([]);
 
-  const onNodeDragStart: NodeDragHandler = useCallback((_evt, node) => {
+  const onNodeDragStart: NodeDragHandler = (_evt, node) => {
     dragRef.current = node;
-  }, []);
+  };
 
-  const onNodeDrag: NodeDragHandler = useCallback((_evt, node) => {
+  const onNodeDrag: NodeDragHandler = (_evt, node) => {
     let { centerX, centerY } = nodeCenter(node);
 
     if (node.parentNode) {
@@ -117,13 +109,13 @@ export const useAlignmentGuide = () => {
     });
 
     setAlignedNodes(alignedNodes.map(([_alignDir, n]) => n));
-  }, []);
+  };
 
-  const onNodeDragStop: NodeDragHandler = useCallback((_evt, _node) => {
+  const onNodeDragStop: NodeDragHandler = (_evt, _node) => {
     setEdges((edges) => removeGuideEdges(edges));
     dragRef.current = null;
     setAlignedNodes([]);
-  }, []);
+  };
 
   useEffect(() => {
     // console.log(alignedNodes);

--- a/src/app/components/ErDiagram/useColaLayoutedElements.tsx
+++ b/src/app/components/ErDiagram/useColaLayoutedElements.tsx
@@ -1,18 +1,28 @@
 import { useCallback } from "react";
 import { useReactFlow, useStore } from "reactflow";
 import * as cola from "webcola";
-import { adjustChildNodePosition } from "../../util/common";
+import { updateNodePosition } from "../../util/common";
+import { NodeConstraints } from "../../types/ErDiagram";
+
+type ColaConstraints = (
+  | {
+      type: "alignment";
+      axis: "x" | "y";
+      offsets: { node: number; offset: string }[];
+    }
+  | {
+      type: "inequality";
+      axis: "x" | "y";
+      left: number;
+      right: number;
+      gap: number;
+    }
+)[];
 
 export const useColaLayoutedElements = () => {
   const { getNodes, setNodes, getEdges, fitView } = useReactFlow<{
-    constraints?: {
-      type: "string";
-      axis: "x" | "y";
-      offsets: {
-        node: string;
-        offset: string;
-      }[];
-    }[];
+    constraints?: NodeConstraints;
+    label: string;
     width: number;
     height: number;
   }>();
@@ -41,19 +51,13 @@ export const useColaLayoutedElements = () => {
       };
     });
 
-    const constraints = [];
+    let constraints: ColaConstraints = [];
     for (const node of nodes) {
       if (node.data.constraints) {
-        for (const con of node.data.constraints) {
-          constraints.push({
-            type: "alignment",
-            axis: con.axis,
-            offsets: con.offsets.map((offset) => ({
-              node: node2idx.get(offset.node)!,
-              offset: offset.offset,
-            })),
-          });
-        }
+        constraints = nodeConstrainsToColaConstraints(
+          node.data.constraints,
+          node2idx,
+        );
       }
     }
 
@@ -62,33 +66,51 @@ export const useColaLayoutedElements = () => {
       target: node2idx.get(edge.target)!,
     }));
 
-    const aggregationNodeIds = layoutNodes
+    const entityGroups: (cola.Group & { id: string; idx: number })[] =
+      layoutNodes
+        .filter((n) => n.type === "entity")
+        .map((entity) => entity.id)
+        .map((entityId, idx) => ({
+          id: entityId,
+          idx: idx,
+          leaves: layoutNodes.filter(
+            (n) => n.id === entityId || n.parentNode === entityId,
+          ),
+          padding: 10,
+        }));
+
+    const aggregationGroups: (cola.Group & { id: string })[] = layoutNodes
       .filter((n) => n.type === "aggregation")
-      .map((n) => n.id);
-
-    const aggregationGroups: (cola.Group & { id: string })[] =
-      aggregationNodeIds.map((aggNodeId) => {
-        const childrenNodes = layoutNodes.filter(
-          (n) => n.parentNode === aggNodeId,
-        );
-
+      .map((aggregation) => aggregation.id)
+      .map((aggId) => {
+        const children = layoutNodes.filter((n) => n.parentNode === aggId);
         return {
-          id: aggNodeId,
-          leaves: childrenNodes,
+          id: aggId,
+          leaves: children,
+          groups: entityGroups.filter((group) =>
+            children.some((c) => c.id === group.id),
+          ),
+          // .map((g) => g.idx),
           padding: 10,
         };
       });
-
-    const c = new cola.Layout().linkDistance(100).size([2000, 2000]);
-    c.nodes(layoutNodes)
+    console.log(constraints);
+    new cola.Layout()
+      .linkDistance(100)
+      .size([2000, 2000])
+      .nodes(layoutNodes)
       .links(layoutEdges)
-      .groups(aggregationGroups)
+      .groups([...entityGroups, ...aggregationGroups])
       .constraints(constraints)
-      .start(1, 0, 3);
+      // .groups(aggregationGroups)
+      .jaccardLinkLengths(100)
+      .flowLayout("x", 500)
+      .start(3, 0, 100);
 
     // manually move the aggregation nodes
     for (const aggGroup of aggregationGroups) {
       if (aggGroup.leaves!.length < 2) continue;
+      const PADDING = 50;
       const agg = layoutNodes.find((n) => n.id === aggGroup.id)!;
       let [minX, minY, maxX, maxY] = [Infinity, Infinity, -Infinity, -Infinity];
       for (const leaf of aggGroup.leaves!) {
@@ -99,17 +121,51 @@ export const useColaLayoutedElements = () => {
       }
 
       agg.data = {
-        height: maxY - minY,
-        width: maxX - minX,
+        label: agg.data.label,
+        height: maxY - minY + PADDING,
+        width: maxX - minX + PADDING,
       };
-      agg.x = minX;
-      agg.y = minY;
+      agg.x = minX - PADDING / 2;
+      agg.y = minY - PADDING / 2;
     }
 
-    setNodes(
-      layoutNodes.map((node) => adjustChildNodePosition(node, layoutNodes)),
-    );
+    setNodes(layoutNodes.map((node) => updateNodePosition(node, layoutNodes)));
     window.requestAnimationFrame(() => fitView());
   }, [initialised]);
   return { ColaLayoutElements };
+};
+
+const nodeConstrainsToColaConstraints = (
+  nodeConstraints: NodeConstraints,
+  node2idxMap: Map<string, number>,
+): ColaConstraints => {
+  const constraints = [];
+  for (const con of nodeConstraints) {
+    if (con.type === "alignment") {
+      const offsets = [];
+      for (const offsetObj of con.offsets) {
+        offsets.push({
+          node: node2idxMap.get(offsetObj.node)!,
+          offset: offsetObj.offset,
+        });
+      }
+      constraints.push({
+        type: con.type,
+        axis: con.axis,
+        offsets,
+      });
+    }
+
+    if (con.type === "inequality") {
+      constraints.push({
+        type: con.type,
+        axis: con.axis,
+        left: node2idxMap.get(con.left)!,
+        right: node2idxMap.get(con.right)!,
+        gap: con.gap,
+      });
+    }
+  }
+
+  return constraints;
 };

--- a/src/app/components/ErDiagram/useColaLayoutedElements.tsx
+++ b/src/app/components/ErDiagram/useColaLayoutedElements.tsx
@@ -1,0 +1,115 @@
+import { useCallback } from "react";
+import { useReactFlow, useStore } from "reactflow";
+import * as cola from "webcola";
+import { adjustChildNodePosition } from "../../util/common";
+
+export const useColaLayoutedElements = () => {
+  const { getNodes, setNodes, getEdges, fitView } = useReactFlow<{
+    constraints?: {
+      type: "string";
+      axis: "x" | "y";
+      offsets: {
+        node: string;
+        offset: string;
+      }[];
+    }[];
+    width: number;
+    height: number;
+  }>();
+
+  const initialised = useStore((store) =>
+    [...store.nodeInternals.values()].every(
+      (node) => node.width && node.height,
+    ),
+  );
+
+  const ColaLayoutElements = useCallback((): void => {
+    const nodes = getNodes();
+    // ensure reactflow has initialised nodes
+    if (!initialised || nodes.length === 0) return;
+
+    const node2idx = new Map<string, number>();
+    const layoutNodes = nodes.map((node, idx) => {
+      node2idx.set(node.id, idx);
+      return {
+        ...node,
+        width: node.width || 0,
+        height: node.height || 0,
+        index: idx,
+        x: 0,
+        y: 0,
+      };
+    });
+
+    const constraints = [];
+    for (const node of nodes) {
+      if (node.data.constraints) {
+        for (const con of node.data.constraints) {
+          constraints.push({
+            type: "alignment",
+            axis: con.axis,
+            offsets: con.offsets.map((offset) => ({
+              node: node2idx.get(offset.node)!,
+              offset: offset.offset,
+            })),
+          });
+        }
+      }
+    }
+
+    const layoutEdges = getEdges().map((edge) => ({
+      source: node2idx.get(edge.source)!,
+      target: node2idx.get(edge.target)!,
+    }));
+
+    const aggregationNodeIds = layoutNodes
+      .filter((n) => n.type === "aggregation")
+      .map((n) => n.id);
+
+    const aggregationGroups: (cola.Group & { id: string })[] =
+      aggregationNodeIds.map((aggNodeId) => {
+        const childrenNodes = layoutNodes.filter(
+          (n) => n.parentNode === aggNodeId,
+        );
+
+        return {
+          id: aggNodeId,
+          leaves: childrenNodes,
+          padding: 10,
+        };
+      });
+
+    const c = new cola.Layout().linkDistance(100).size([2000, 2000]);
+    c.nodes(layoutNodes)
+      .links(layoutEdges)
+      .groups(aggregationGroups)
+      .constraints(constraints)
+      .start(1, 0, 3);
+
+    // manually move the aggregation nodes
+    for (const aggGroup of aggregationGroups) {
+      if (aggGroup.leaves!.length < 2) continue;
+      const agg = layoutNodes.find((n) => n.id === aggGroup.id)!;
+      let [minX, minY, maxX, maxY] = [Infinity, Infinity, -Infinity, -Infinity];
+      for (const leaf of aggGroup.leaves!) {
+        minX = Math.min(minX, leaf.x);
+        minY = Math.min(minY, leaf.y);
+        maxX = Math.max(maxX, leaf.x + leaf.width!);
+        maxY = Math.max(maxY, leaf.y + leaf.height!);
+      }
+
+      agg.data = {
+        height: maxY - minY,
+        width: maxX - minX,
+      };
+      agg.x = minX;
+      agg.y = minY;
+    }
+
+    setNodes(
+      layoutNodes.map((node) => adjustChildNodePosition(node, layoutNodes)),
+    );
+    window.requestAnimationFrame(() => fitView());
+  }, [initialised]);
+  return { ColaLayoutElements };
+};

--- a/src/app/components/ErDiagram/useD3LayoutedElements.tsx
+++ b/src/app/components/ErDiagram/useD3LayoutedElements.tsx
@@ -18,7 +18,7 @@ export const useD3LayoutedElements = () => {
     ),
   );
 
-  const D3LayoutElements = useCallback((): void => {
+  const d3LayoutElements = useCallback((): void => {
     const nodes = getNodes().map((node) => ({
       ...node,
       x: 0,
@@ -48,5 +48,5 @@ export const useD3LayoutedElements = () => {
     setNodes(nodes.map((node) => adjustChildNodePosition(node, nodes)));
     window.requestAnimationFrame(() => fitView());
   }, [initialised]);
-  return { D3LayoutElements };
+  return { d3LayoutElements };
 };

--- a/src/app/components/ErDiagram/useD3LayoutedElements.tsx
+++ b/src/app/components/ErDiagram/useD3LayoutedElements.tsx
@@ -7,7 +7,7 @@ import {
   forceX,
   forceY,
 } from "d3-force";
-import { adjustChildNodePosition } from "../../util/common";
+import { updateNodePosition } from "../../util/common";
 
 export const useD3LayoutedElements = () => {
   const { getNodes, setNodes, getEdges, fitView } = useReactFlow();
@@ -45,7 +45,7 @@ export const useD3LayoutedElements = () => {
       )
       .tick(5500);
 
-    setNodes(nodes.map((node) => adjustChildNodePosition(node, nodes)));
+    setNodes(nodes.map((node) => updateNodePosition(node, nodes)));
     window.requestAnimationFrame(() => fitView());
   }, [initialised]);
   return { d3LayoutElements };

--- a/src/app/components/ErDiagram/useLayoutedElements.tsx
+++ b/src/app/components/ErDiagram/useLayoutedElements.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { useReactFlow, Node, Edge } from "reactflow";
 import ELK, { ElkNode } from "elkjs/lib/elk.bundled.js";
-import { adjustChildNodePosition } from "../../util/common";
+import { updateNodePosition } from "../../util/common";
 import { LayoutedNode } from "../../util/common";
 
 const elk = new ELK();
@@ -111,10 +111,7 @@ const getLayoutedElements = async (
       });
     } else {
       layoutedNodes.push(
-        adjustChildNodePosition(
-          node as LayoutedNode,
-          children as LayoutedNode[],
-        ),
+        updateNodePosition(node as LayoutedNode, children as LayoutedNode[]),
       );
     }
   });

--- a/src/app/components/ErDiagram/useLayoutedElements.tsx
+++ b/src/app/components/ErDiagram/useLayoutedElements.tsx
@@ -85,8 +85,8 @@ const getLayoutedElements = async (
   const layoutedNodes: Node[] = [];
 
   children?.forEach((node) => {
+    // if it is an aggregation, mutate the subgraph back into a regular node
     if (Object.prototype.hasOwnProperty.call(node, "children")) {
-      // mutate the aggregation subgraph back into a regular node
       const originalAgg = flowNodes.find((fn) => fn.id === node.id);
       node = {
         ...originalAgg,

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,6 +1,8 @@
 const Header = () => {
   return (
-    <div className="h-full w-1/3 text-neutral-50"> ER Diagram Editor </div>
+    <div className=" flex h-full w-1/3 items-center text-neutral-50">
+      ER Diagram Editor
+    </div>
   );
 };
 

--- a/src/app/types/ErDiagram.ts
+++ b/src/app/types/ErDiagram.ts
@@ -2,17 +2,26 @@ import { CSSProperties, ComponentType } from "react";
 import { EdgeMarkerType, EdgeTypes, NodeProps } from "reactflow";
 import { Node, Edge } from "reactflow";
 
-type constraints = {
-  type: string;
-  axis: "x" | "y";
-  offsets: { node: string; offset: string }[];
-}[];
+export type NodeConstraints = (
+  | {
+      type: "alignment";
+      axis: "x" | "y";
+      offsets: { node: string; offset: string }[];
+    }
+  | {
+      type: "inequality";
+      axis: "x" | "y";
+      left: string;
+      right: string;
+      gap: number;
+    }
+)[];
 
 export type EntityNode = Node<
   {
     label: string;
     isWeak: boolean;
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "entity"
 >;
@@ -22,7 +31,7 @@ export type EntityAttributeNode = Node<
     label: string;
     isKey: boolean;
     entityIsWeak: boolean;
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "entity-attribute"
 >;
@@ -30,7 +39,7 @@ export type EntityAttributeNode = Node<
 export type CompositeAttributeNode = Node<
   {
     label: string;
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "composite-attribute"
 >;
@@ -39,7 +48,7 @@ export type RelationshipNode = Node<
   {
     label: string;
     hasDependant: boolean;
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "relationship"
 >;
@@ -47,7 +56,7 @@ export type RelationshipNode = Node<
 export type RelationshipAttributeNode = Node<
   {
     label: string;
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "relationship-attribute"
 >;
@@ -57,14 +66,14 @@ export type AggregationNode = Node<
     label: string;
     width?: number;
     height?: number;
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "aggregation"
 >;
 
 export type IsANode = Node<
   {
-    constraints?: constraints;
+    constraints?: NodeConstraints;
   },
   "isA"
 >;
@@ -72,7 +81,7 @@ export type IsANode = Node<
 export type EntityEdge = Edge<{
   cardinality: string;
   isTotalParticipation: boolean;
-  constraints?: constraints;
+  constraints?: NodeConstraints;
 }>;
 
 export type ErNode =

--- a/src/app/types/ErDiagram.ts
+++ b/src/app/types/ErDiagram.ts
@@ -22,6 +22,7 @@ export type EntityNode = Node<
     label: string;
     isWeak: boolean;
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "entity"
 >;
@@ -32,6 +33,7 @@ export type EntityAttributeNode = Node<
     isKey: boolean;
     entityIsWeak: boolean;
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "entity-attribute"
 >;
@@ -40,6 +42,7 @@ export type CompositeAttributeNode = Node<
   {
     label: string;
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "composite-attribute"
 >;
@@ -49,6 +52,7 @@ export type RelationshipNode = Node<
     label: string;
     hasDependant: boolean;
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "relationship"
 >;
@@ -57,6 +61,7 @@ export type RelationshipAttributeNode = Node<
   {
     label: string;
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "relationship-attribute"
 >;
@@ -67,6 +72,7 @@ export type AggregationNode = Node<
     width?: number;
     height?: number;
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "aggregation"
 >;
@@ -74,6 +80,7 @@ export type AggregationNode = Node<
 export type IsANode = Node<
   {
     constraints?: NodeConstraints;
+    erId?: string;
   },
   "isA"
 >;
@@ -82,6 +89,7 @@ export type EntityEdge = Edge<{
   cardinality: string;
   isTotalParticipation: boolean;
   constraints?: NodeConstraints;
+  erId?: string;
 }>;
 
 export type ErNode =

--- a/src/app/types/ErDiagram.ts
+++ b/src/app/types/ErDiagram.ts
@@ -2,10 +2,17 @@ import { CSSProperties, ComponentType } from "react";
 import { EdgeMarkerType, EdgeTypes, NodeProps } from "reactflow";
 import { Node, Edge } from "reactflow";
 
+type constraints = {
+  type: string;
+  axis: "x" | "y";
+  offsets: { node: string; offset: string }[];
+}[];
+
 export type EntityNode = Node<
   {
     label: string;
     isWeak: boolean;
+    constraints?: constraints;
   },
   "entity"
 >;
@@ -15,12 +22,16 @@ export type EntityAttributeNode = Node<
     label: string;
     isKey: boolean;
     entityIsWeak: boolean;
+    constraints?: constraints;
   },
   "entity-attribute"
 >;
 
 export type CompositeAttributeNode = Node<
-  { label: string },
+  {
+    label: string;
+    constraints?: constraints;
+  },
   "composite-attribute"
 >;
 
@@ -28,6 +39,7 @@ export type RelationshipNode = Node<
   {
     label: string;
     hasDependant: boolean;
+    constraints?: constraints;
   },
   "relationship"
 >;
@@ -35,6 +47,7 @@ export type RelationshipNode = Node<
 export type RelationshipAttributeNode = Node<
   {
     label: string;
+    constraints?: constraints;
   },
   "relationship-attribute"
 >;
@@ -44,15 +57,22 @@ export type AggregationNode = Node<
     label: string;
     width?: number;
     height?: number;
+    constraints?: constraints;
   },
   "aggregation"
 >;
 
-export type IsANode = Node<Record<string, never>, "isA">;
+export type IsANode = Node<
+  {
+    constraints?: constraints;
+  },
+  "isA"
+>;
 
 export type EntityEdge = Edge<{
   cardinality: string;
   isTotalParticipation: boolean;
+  constraints?: constraints;
 }>;
 
 export type ErNode =

--- a/src/app/util/ErdocExamples.ts
+++ b/src/app/util/ErdocExamples.ts
@@ -28,8 +28,8 @@ entity loan {
     type
 }
 
-relation accts(bank_branch 1, account N!)
-relation loans(bank_branch 1, loan N!)
+relation accts(Bank_With_Branches 1, account N!)
+relation loans(Bank_With_Branches 1, loan N!)
 
 entity customer {
     ssn key
@@ -44,6 +44,10 @@ entity premium_customer extends customer {
 
 relation a_c(customer N, account M!)
 relation l_c(customer N, loan M!)
+
+aggregation Bank_With_Branches(has_branches)
+
+
     `,
 
 company:
@@ -96,5 +100,294 @@ relation Dependent_of(Employee 1, Dependent N!)
 
 
 
+`,
+
+large: `entity university {
+    university_id key
+    name
+    address
+}
+
+entity department {
+    dept_id key
+    name
+    head
+}
+
+relation has_department(university 1!, department N!)
+
+entity professor {
+    professor_id key
+    name
+    email
+}
+
+entity student {
+    student_id key
+    name
+    email
+}
+
+entity course {
+    course_id key
+    name
+    credits
+}
+
+relation teaches(professor 1, course N!)
+
+entity enrollment {
+    enrollment_id key
+    enrollment_date
+    grade
+}
+
+relation enrolls_in(student 1, course 1!, enrollment N!)
+
+entity library {
+    library_id key
+    name
+    location
+}
+
+entity book {
+    book_id key
+    title
+    author
+    publication_date
+}
+
+relation contains(library 1, book N!)
+
+entity publisher {
+    publisher_id key
+    name
+    location
+}
+
+entity author {
+    author_id key
+    name
+    birth_date
+}
+
+relation publishes(publisher 1!, book N!)
+relation writes(author 1, book N!)
+
+entity conference {
+    conference_id key
+    name
+    date
+    location
+}
+
+entity paper {
+    paper_id key
+    title
+    abstract
+}
+
+relation presents(professor 1!, paper N!) {
+    presentation_date
+}
+
+entity event {
+    event_id key
+    name
+    date
+    location
+}
+
+relation attends(student 1!, event N!) {
+    attendance_date
+}
+
+entity project {
+    project_id key
+    name
+    description
+}
+
+entity task {
+    task_id key
+    name
+    deadline
+}
+
+relation works_on(student 1!, project N!, task M!)
+
+entity hospital {
+    hospital_id key
+    name
+    address
+}
+
+entity doctor {
+    doctor_id key
+    name
+    specialization
+}
+
+relation works_at(doctor 1, hospital N!)
+
+entity patient depends on treats {
+    patient_id pkey
+    name
+    dob
+}
+
+relation treats(doctor 1!, patient N!) {
+    treatment_date
+}
+
+entity medication {
+    medication_id key
+    name
+    dosage
+}
+
+relation prescribes(doctor 1, medication N!)
+
+entity pharmacy {
+    pharmacy_id key
+    name
+    location
+}
+
+relation dispenses(medication 1!, pharmacy N!) {
+    dispensing_date
+}
+
+entity bank {
+    bank_id key
+    name
+    address
+}
+
+entity branch depends on has_branches {
+    branch_id pkey
+    branch_no
+    location
+}
+
+relation has_branches(bank 1!, branch N!)
+
+entity account {
+    account_id key
+    balance
+    type
+}
+
+entity loan {
+    loan_id key
+    amount
+    type
+}
+
+relation accts(bank_with_branches 1, account N!)
+relation loans(bank_with_branches 1, loan N!)
+
+entity customer {
+    customer_id key
+    name
+    address
+    phone
+}
+
+entity premium_customer extends customer {
+    discount
+}
+
+relation has_account(customer N, account M!)
+relation has_loan(customer N, loan M!)
+
+aggregation bank_with_branches(has_branches)
+
+entity employee {
+    employee_id key
+    name
+    salary
+}
+
+entity manager extends employee {
+    department
+}
+
+relation works_at(employee 1!, bank_with_branches N!)
+
+entity transaction {
+    transaction_id key
+    date
+    amount
+}
+
+relation makes(account 1!, transaction N!)
+
+entity atm_machine {
+    atm_id key
+    location
+}
+
+relation located_at(atm_machine 1, bank_with_branches N!)
+
+entity credit_card {
+    card_no key
+    expiration_date
+    credit_limit
+}
+
+relation issued_to(credit_card 1!, customer N!)
+
+entity mortgage extends loan {
+    property_address
+    interest_rate
+}
+
+entity checking_account extends account {
+    monthly_fee
+    overdraft_protection
+}
+
+relation owns(customer 1!, checking_account N!)
+relation has(credit_card 1!, checking_account N!)
+
+entity savings_account extends account {
+    interest_rate
+    minimum_balance
+}
+
+relation owns(customer 1!, savings_account N!)
+relation has(credit_card 1!, savings_account N!)
+
+entity transaction_log {
+    log_id key
+    description
+    date
+}
+
+relation logs(transaction_log 1, transaction N!)
+
+entity service_provider {
+    provider_id key
+    name
+    location
+}
+
+entity service {
+    service_id key
+    name
+    description
+}
+
+entity service_location extends service {
+    location
+}
+
+relation provides(service_provider 1, service_location N!, service M!)
+relation offers(customer N, service_location M!)
+relation requires(service M!, service_location N!)
+
 `
 };
+
+export const EXAMPLE_NAMES = Object.keys(EXAMPLES);

--- a/src/app/util/common.ts
+++ b/src/app/util/common.ts
@@ -23,19 +23,10 @@ export const adjustChildNodePosition = (
   node: LayoutedNode,
   nodes: LayoutedNode[],
 ): LayoutedNode => {
-  if (
-    // if the node is an attribute, we need to update its position relative to its parent
-    [
-      "composite-attribute",
-      "entity-attribute",
-      "relationship-attribute",
-    ].includes(node.type!)
-  ) {
-    const parentNode = nodes.find((n) => n.id === node.parentNode);
-    if (parentNode && parentNode.type !== "aggregation") {
-      node.x = node.x - parentNode.x;
-      node.y = node.y - parentNode.y;
-    }
+  const parentNode = nodes.find((n) => n.id === node.parentNode);
+  if (parentNode) {
+    node.x = node.x - parentNode.x;
+    node.y = node.y - parentNode.y;
   }
   return { ...node, position: { x: node.x, y: node.y } };
 };

--- a/src/app/util/common.ts
+++ b/src/app/util/common.ts
@@ -19,7 +19,7 @@ export const createRelationshipNodeId = (relationshipId: string): string => {
 
 export type LayoutedNode = Node & { x: number; y: number };
 
-export const adjustChildNodePosition = (
+export const updateNodePosition = (
   node: LayoutedNode,
   nodes: LayoutedNode[],
 ): LayoutedNode => {

--- a/src/app/util/erToReactflowElements.ts
+++ b/src/app/util/erToReactflowElements.ts
@@ -361,5 +361,42 @@ export const erToReactflowElements = (
     }
   }
 
+  // now that we've processed all the ER logic, we convert the ids to just the index in the array.
+  // this way, if  we rename an entity in the text editor the id will stay the same
+  renameIdsToNumeric(newNodes, newEdges);
+
   return [newNodes, newEdges];
+};
+
+const renameIdsToNumeric = (nodes: ErNode[], edges: Edge[]) => {
+  const id2index = new Map<string, string>();
+  for (const [index, node] of nodes.entries()) {
+    id2index.set(node.id, index.toString());
+    node.data.erId = node.id;
+    node.id = index.toString();
+  }
+
+  for (const node of nodes) {
+    if (node.parentNode) {
+      node.parentNode = id2index.get(node.parentNode)!;
+    }
+    if (node.data.constraints) {
+      for (const con of node.data.constraints) {
+        if (con.type === "alignment") {
+          for (const offset of con.offsets) {
+            offset.node = id2index.get(offset.node)!;
+          }
+        }
+        if (con.type === "inequality") {
+          con.left = id2index.get(con.left)!;
+          con.right = id2index.get(con.right)!;
+        }
+      }
+    }
+  }
+
+  for (const edge of edges) {
+    edge.source = id2index.get(edge.source)!;
+    edge.target = id2index.get(edge.target)!;
+  }
 };

--- a/src/app/util/erToReactflowElements.ts
+++ b/src/app/util/erToReactflowElements.ts
@@ -28,7 +28,19 @@ const inheritanceToReactflowElements = (
   const isANode: IsANode = {
     id: isANodeId,
     type: "isA",
-    data: {},
+    data: {
+      constraints: [
+        {
+          type: "alignment",
+          axis: "x",
+          offsets: [
+            { node: parentEntityNodeId, offset: "0" },
+            { node: isANodeId, offset: "0" },
+            { node: childEntityNodeId, offset: "0" },
+          ],
+        },
+      ],
+    },
     position: { x: 0, y: 0 },
   };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,6 +59,11 @@
         "AGGREGATION_RELATIONSHIP_NOT_EXISTS": "Aggregation \"{aggregationName}\" encapsulates non-existent relationship \"{relationshipName}\"",
 
         "AGGREGATION_RELATIONSHIP_ALREADY_USED": "Aggregation \"{aggregationName}\" encapsulates relationship \"{relationshipName}\", which is already used"
+      },
+      "editorHeader": {
+        "copy": "Copy code",
+        "undo": "Undo (Ctrl+Z)",
+        "redo": "Redo (Ctrl+Y)"
       }
     }
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,7 +9,8 @@
     "examples": {
       "_title": "Examples",
       "bank": "Bank",
-      "company": "Company"
+      "company": "Company",
+      "large": "Very big example"
     },
 
     "erDiagram": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -9,7 +9,8 @@
     "examples": {
       "_title": "Examples",
       "bank": "Bank",
-      "company": "Company"
+      "company": "Company",
+      "large": "Very big example"
     },
 
     "erDiagram": {
@@ -58,6 +59,11 @@
         "AGGREGATION_RELATIONSHIP_NOT_EXISTS": "Aggregation \"{aggregationName}\" encapsulates non-existent relationship \"{relationshipName}\"",
 
         "AGGREGATION_RELATIONSHIP_ALREADY_USED": "Aggregation \"{aggregationName}\" encapsulates relationship \"{relationshipName}\", which is already used"
+      },
+      "editorHeader": {
+        "copy": "Copy code",
+        "undo": "Undo (Ctrl+Z)",
+        "redo": "Redo (Ctrl+Y)"
       }
     }
   }


### PR DESCRIPTION
feats:
    - Alignment guides when dragging nodes.
    - Consume examples from API.
    - Editor header with copy to clipboard, undo and redo buttons. 
fixes:
    - Renaming, moving text in the editor, *generally*, won't cause the existing nodes to move.
 wip:
    - Experimental layout with `Cola.js`.