### PR TITLE
fix: prevent crash when handles are not found

### DIFF
--- a/src/app/components/CodeEditor/CodeEditor.tsx
+++ b/src/app/components/CodeEditor/CodeEditor.tsx
@@ -176,7 +176,7 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
       <EditorHeader editorRef={editorRef} />
       <Box
         resize="none"
-        pt={1}
+        pt={0}
         flex={"1 1 auto"}
         width="full"
         height="max-content"
@@ -192,6 +192,7 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
           options={{
             autoClosingBrackets: "always",
             scrollBeyondLastLine: false,
+            fixedOverflowWidgets: true,
             minimap: {
               enabled: false,
             },

--- a/src/app/components/ErDiagram/notations/useEdgePath.tsx
+++ b/src/app/components/ErDiagram/notations/useEdgePath.tsx
@@ -54,8 +54,10 @@ const getHandleCoordsByPosition = (
       handleMatchCondition(h),
     );
 
-  if(handle === undefined) {
-    console.log("COULD NOT FIND MATCHING", node.data.erId, handlePrefix)
+  if (handle === undefined) {
+    // FIXME!: See issue #1, sometimes the 5 handles per side are not created when they should be
+    // this hack doesn't cause edges to be routed differently, weird.
+    return [0, 0];
   }
 
   const offsetX = handle!.width / 2;
@@ -135,7 +137,7 @@ export const useEdgePath = (
 
   const angle = Math.atan2(ty - sy, tx - sx);
   const dist = Math.sqrt((tx - sx) ** 2 + (ty - sy) ** 2);
-  const labelDist = isOrthogonal? dist /2 : dist / 3;
+  const labelDist = isOrthogonal ? dist / 2 : dist / 3;
   const labelX = sx + labelDist * Math.cos(angle);
   const labelY = sy + labelDist * Math.sin(angle);
 


### PR DESCRIPTION
Causes #18 not to crash, doesn't seem to cause incosistencies in the diagram itself.