### PR TITLE
feat: persist state

### DIFF
--- a/src/app/components/CodeEditor/CodeEditor.tsx
+++ b/src/app/components/CodeEditor/CodeEditor.tsx
@@ -78,6 +78,8 @@ const erdocTokenizer: languages.IMonarchLanguage = {
   },
 };
 
+const LOCAL_STORAGE_EDITOR_CONTENT_KEY = "monaco-editor-content";
+
 const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
   const [selectedExample, setSelectedExample] = useState<string | null>(null);
 
@@ -114,6 +116,7 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
 
   const handleEditorContent = (content: string) => {
     try {
+      localStorage.setItem(LOCAL_STORAGE_EDITOR_CONTENT_KEY, content);
       const [erDoc, errors] = getERDoc(content);
       onErDocChange(erDoc);
       const errorMsgs: ErrorMessage[] = errors.map((err) => ({
@@ -137,7 +140,10 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
 
   const handleEditorMount: OnMount = (editor, m) => {
     editorRef.current = editor;
-    handleEditorContent(DEFAULT_CONTENT);
+    const prevContent = localStorage.getItem(LOCAL_STORAGE_EDITOR_CONTENT_KEY);
+    const initialContent = prevContent ?? DEFAULT_CONTENT;
+    editor.setValue(initialContent);
+    handleEditorContent(initialContent);
     // mount erdoc language
     m.languages.register({ id: "erdoc" });
     m.languages.setMonarchTokensProvider("erdoc", erdocTokenizer);
@@ -147,7 +153,6 @@ const CodeEditor = ({ onErDocChange }: ErrorReportingEditorProps) => {
       m.editor.defineTheme(themeName, theme);
     }
     m.editor.setTheme(DEFAULT_THEME);
-    editor.setValue(DEFAULT_CONTENT);
   };
 
   useEffect(() => {

--- a/src/app/components/ErDiagram/ControlPanel.tsx
+++ b/src/app/components/ErDiagram/ControlPanel.tsx
@@ -1,17 +1,20 @@
-import { useLayoutedElements } from "./hooks/useLayoutedElements";
-import { Controls, ControlButton, useReactFlow } from "reactflow";
 import { useTranslations } from "next-intl";
-import { colors } from "../../util/colors";
 import { HiSparkles } from "react-icons/hi2";
+import { ControlButton, Controls } from "reactflow";
+import { colors } from "../../util/colors";
+import { useLayoutedElements } from "./hooks/useLayoutedElements";
 
-export const ControlPanel = () => {
+type ControlPanelProps = {
+  onLayoutClick: () => void;
+};
+
+export const ControlPanel = ({ onLayoutClick }: ControlPanelProps) => {
   const { layoutElements } = useLayoutedElements();
-  const { fitView } = useReactFlow();
   const t = useTranslations("home.erDiagram");
 
   const handleLayoutClick = () => {
     void layoutElements().then(() => {
-      window.requestAnimationFrame(() => fitView());
+      setTimeout(onLayoutClick, 100);
     });
   };
 

--- a/src/app/components/ErDiagram/hooks/useDiagramToLocalStorage.tsx
+++ b/src/app/components/ErDiagram/hooks/useDiagramToLocalStorage.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useState } from "react";
+import { ReactFlowInstance, useReactFlow } from "reactflow";
+
+const LOCAL_STORAGE_FLOW_KEY = "er-flow";
+
+export const useDiagramToLocalStorage = () => {
+  const { setNodes, setEdges, setViewport } = useReactFlow();
+  const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
+
+  const saveToLocalStorage = useCallback(() => {
+    if (rfInstance) {
+      const flow = rfInstance.toObject();
+      localStorage.setItem(LOCAL_STORAGE_FLOW_KEY, JSON.stringify(flow));
+    }
+  }, [rfInstance]);
+
+  const loadFromLocalStorage = () => {
+    const storedFlow = localStorage.getItem(LOCAL_STORAGE_FLOW_KEY);
+    if (storedFlow) {
+      const flow = JSON.parse(storedFlow);
+      const { x = 0, y = 0, zoom = 1 } = flow.viewport;
+      setNodes(flow.nodes || []);
+      setEdges(flow.edges || []);
+      setViewport({ x, y, zoom });
+      return true;
+    }
+    return false;
+  };
+
+  return { saveToLocalStorage, loadFromLocalStorage, setRfInstance };
+};


### PR DESCRIPTION
Content from the text editor is saved to `localStorage` on every change.
The ER Diagram is saved to `localStorage` when user positions nodes, or changes the ERD using the text editor.

We need to `setTimeout` some saves to let Reactflow update its state first.