### PR TITLE
fix: state-sync

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,25 +4,32 @@ import Body from "../components/Body";
 import Header from "../components/Header/Header";
 import { Context } from "../context";
 import { erDocWithoutLocation } from "../util/common";
-import { ErDocChangeEvent } from "../types/CodeEditor";
+import { DiagramChange, ErDocChangeEvent } from "../types/CodeEditor";
 import { ER } from "../../ERDoc/types/parser/ER";
 
 const Page = () => {
   const [autoLayoutEnabled, setAutoLayoutEnabled] = useState<boolean | null>(
     null,
   );
-  const [loadedDiagramFromOutside, setLoadedDiagramFromOutside] =
-    useState<boolean>(false);
 
   const [erDoc, setErDoc] = useState<ER | null>(null);
+  const [lastChange, setLastChange] = useState<DiagramChange | null>(null);
 
   const onErDocChange = (evt: ErDocChangeEvent) => {
     switch (evt.type) {
       case "json": {
+        setLastChange({
+          type: "json",
+          positions: evt.positions,
+        });
         return;
       }
 
       case "localStorage": {
+        setLastChange({
+          type: "localStorage",
+          positions: evt.positions,
+        });
         return;
       }
 
@@ -51,8 +58,6 @@ const Page = () => {
       value={{
         autoLayoutEnabled,
         setAutoLayoutEnabled,
-        loadedDiagramFromOutside,
-        setLoadedDiagramFromOutside,
       }}
     >
       <div className="flex h-screen w-screen flex-col">
@@ -60,7 +65,11 @@ const Page = () => {
           <Header onErDocChange={onErDocChange} />
         </div>
         <div className="h-[90%] w-full min-[1340px]:h-[95%]">
-          <Body erDoc={erDoc} onErDocChange={onErDocChange} />
+          <Body
+            erDoc={erDoc}
+            lastChange={lastChange}
+            onErDocChange={onErDocChange}
+          />
         </div>
       </div>
     </Context.Provider>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,6 +3,9 @@ import { useState } from "react";
 import Body from "../components/Body";
 import Header from "../components/Header/Header";
 import { Context } from "../context";
+import { erDocWithoutLocation } from "../util/common";
+import { ErDocChangeEvent } from "../types/CodeEditor";
+import { ER } from "../../ERDoc/types/parser/ER";
 
 const Page = () => {
   const [autoLayoutEnabled, setAutoLayoutEnabled] = useState<boolean | null>(
@@ -10,6 +13,38 @@ const Page = () => {
   );
   const [loadedDiagramFromOutside, setLoadedDiagramFromOutside] =
     useState<boolean>(false);
+
+  const [erDoc, setErDoc] = useState<ER | null>(null);
+
+  const onErDocChange = (evt: ErDocChangeEvent) => {
+    switch (evt.type) {
+      case "json": {
+        return;
+      }
+
+      case "localStorage": {
+        return;
+      }
+
+      case "userInput": {
+        const { er } = evt;
+        setErDoc((currentEr) => {
+          if (currentEr === null) return er;
+          const currentErNoLoc = erDocWithoutLocation(currentEr);
+          const newErNoLoc = erDocWithoutLocation(er);
+          const sameSemanticValue =
+            JSON.stringify(currentErNoLoc) === JSON.stringify(newErNoLoc);
+          return sameSemanticValue ? currentEr : er;
+        });
+        return;
+      }
+
+      default: {
+        const exhaustiveCheck: never = evt;
+        throw new Error(`Unhandled event type: ${exhaustiveCheck}`);
+      }
+    }
+  };
 
   return (
     <Context.Provider
@@ -22,10 +57,10 @@ const Page = () => {
     >
       <div className="flex h-screen w-screen flex-col">
         <div className="flex h-[10%] w-full justify-between border-b border-b-border  bg-[#232730] min-[1340px]:h-[5%]">
-          <Header />
+          <Header onErDocChange={onErDocChange} />
         </div>
         <div className="h-[90%] w-full min-[1340px]:h-[95%]">
-          <Body />
+          <Body erDoc={erDoc} onErDocChange={onErDocChange} />
         </div>
       </div>
     </Context.Provider>

--- a/src/app/components/Body.tsx
+++ b/src/app/components/Body.tsx
@@ -2,29 +2,21 @@
 import { useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { ER } from "../../ERDoc/types/parser/ER";
-import { erDocWithoutLocation } from "../util/common";
+import useWindowDimensions from "../hooks/useWindowDimensions";
+import { ErDocChangeEvent } from "../types/CodeEditor";
 import CodeEditor from "./CodeEditor/CodeEditor";
 import { ErDiagram } from "./ErDiagram/ErDiagram";
-import useWindowDimensions from "../hooks/useWindowDimensions";
 
-const Body = () => {
-  const [erDoc, setErDoc] = useState<ER | null>(null);
+type BodyProps = {
+  erDoc: ER | null;
+  onErDocChange: (evt: ErDocChangeEvent) => void;
+};
+
+const Body = ({ erDoc, onErDocChange }: BodyProps) => {
   const [erDocHasError, setErDocHasError] = useState<boolean>(false);
   const [dragging, setDragging] = useState<boolean>(false);
-
   const { width } = useWindowDimensions();
   const lg = (width ?? Infinity) >= 1024;
-
-  const onErDocChange = (er: ER) => {
-    setErDoc((currentEr) => {
-      if (currentEr === null) return er;
-      const currentErNoLoc = erDocWithoutLocation(currentEr);
-      const newErNoLoc = erDocWithoutLocation(er);
-      const sameSemanticValue =
-        JSON.stringify(currentErNoLoc) === JSON.stringify(newErNoLoc);
-      return sameSemanticValue ? currentEr : er;
-    });
-  };
 
   return (
     <PanelGroup direction={lg ? "horizontal" : "vertical"}>

--- a/src/app/components/Body.tsx
+++ b/src/app/components/Body.tsx
@@ -3,16 +3,17 @@ import { useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { ER } from "../../ERDoc/types/parser/ER";
 import useWindowDimensions from "../hooks/useWindowDimensions";
-import { ErDocChangeEvent } from "../types/CodeEditor";
+import { DiagramChange, ErDocChangeEvent } from "../types/CodeEditor";
 import CodeEditor from "./CodeEditor/CodeEditor";
 import { ErDiagram } from "./ErDiagram/ErDiagram";
 
 type BodyProps = {
   erDoc: ER | null;
   onErDocChange: (evt: ErDocChangeEvent) => void;
+  lastChange: DiagramChange | null;
 };
 
-const Body = ({ erDoc, onErDocChange }: BodyProps) => {
+const Body = ({ erDoc, lastChange, onErDocChange }: BodyProps) => {
   const [erDocHasError, setErDocHasError] = useState<boolean>(false);
   const [dragging, setDragging] = useState<boolean>(false);
   const { width } = useWindowDimensions();
@@ -44,7 +45,11 @@ const Body = ({ erDoc, onErDocChange }: BodyProps) => {
 
       <Panel defaultSize={60} className={`${!lg ? "float-left" : ""}`}>
         <div className="h-full pt-1">
-          <ErDiagram erDoc={erDoc!} erDocHasError={erDocHasError} />
+          <ErDiagram
+            erDoc={erDoc!}
+            erDocHasError={erDocHasError}
+            lastChange={lastChange}
+          />
         </div>
       </Panel>
     </PanelGroup>

--- a/src/app/components/CodeEditor/CodeEditor.tsx
+++ b/src/app/components/CodeEditor/CodeEditor.tsx
@@ -4,8 +4,11 @@ import { editor, languages } from "monaco-types";
 import { useTranslations } from "next-intl";
 import { useRef, useState } from "react";
 import { getERDoc } from "../../../ERDoc";
-import { ER } from "../../../ERDoc/types/parser/ER";
-import { ErrorMessage, MarkerSeverity } from "../../types/CodeEditor";
+import {
+  ErrorMessage,
+  MarkerSeverity,
+  ErDocChangeEvent,
+} from "../../types/CodeEditor";
 import { colors } from "../../util/colors";
 import getErrorMessage from "../../util/errorMessages";
 import { EditorHeader } from "./EditorHeader";
@@ -17,7 +20,7 @@ import { useJSON } from "../../hooks/useJSON";
 const DEFAULT_EXAMPLE = "company";
 
 type ErrorReportingEditorProps = {
-  onErDocChange: (er: ER) => void;
+  onErDocChange: (evt: ErDocChangeEvent) => void;
   onErrorChange: (hasError: boolean) => void;
 };
 
@@ -93,7 +96,7 @@ const CodeEditor = ({
   const thisEditor = useMonaco();
   const semanticErrT = useTranslations("home.codeEditor.semanticErrorMessages");
   const [errorMessages, setErrorMessages] = useState<ErrorMessage[]>([]);
-  const { importJSON } = useJSON();
+  const { importJSON } = useJSON(onErDocChange);
 
   const setEditorErrors = (
     errorMessages: ErrorMessage[],
@@ -125,7 +128,7 @@ const CodeEditor = ({
       localStorage.setItem(LOCAL_STORAGE_EDITOR_CONTENT_KEY, content);
       const [erDoc, errors] = getERDoc(content);
       onErrorChange(errors.length > 0);
-      onErDocChange(erDoc);
+      onErDocChange({ er: erDoc, type: "userInput" });
       const errorMsgs: ErrorMessage[] = errors.map((err) => ({
         errorMessage: getErrorMessage(semanticErrT, err),
         location: err.location,
@@ -221,7 +224,7 @@ const CodeEditor = ({
         maxHeight={"30%"}
         backgroundColor={colors.textEditorBackground}
       >
-        <ExamplesTable />
+        <ExamplesTable onErDocChange={onErDocChange} />
       </Box>
     </Box>
   );

--- a/src/app/components/CodeEditor/ExamplesTable.tsx
+++ b/src/app/components/CodeEditor/ExamplesTable.tsx
@@ -5,18 +5,23 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { ErJSON, useJSON } from "../../hooks/useJSON";
 import { fetchExample } from "../../util/common";
+import { ErDocChangeEvent } from "../../types/CodeEditor";
+
+type ExamplesTableProps = {
+  onErDocChange: (evt: ErDocChangeEvent) => void;
+};
 
 // TODO: refactor, should request this from server?
 const EXAMPLE_NAMES = ["bank", "company", "subclass", "aggregation", "roles"];
 
-const ExamplesTable = () => {
+const ExamplesTable = ({ onErDocChange }: ExamplesTableProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [cachedExample, setCachedExample] = useState<{
     name: string;
     data: ErJSON;
   } | null>(null);
 
-  const { importJSON } = useJSON();
+  const { importJSON } = useJSON(onErDocChange);
   const t = useTranslations("home.examples");
 
   const onExampleClickHandler = (exampleName: string) => {

--- a/src/app/components/ErDiagram/ErDiagram.tsx
+++ b/src/app/components/ErDiagram/ErDiagram.tsx
@@ -24,12 +24,14 @@ import { useDiagramToLocalStorage } from "../../hooks/useDiagramToLocalStorage";
 import { useLayoutedElements } from "../../hooks/useLayoutedElements";
 import ErNotation from "./notations/DefaultNotation";
 import { useTranslations } from "next-intl";
+import { DiagramChange } from "../../types/CodeEditor";
 
 type ErDiagramProps = {
   erDoc: ER;
   erDocHasError: boolean;
   notation: ErNotation;
   notationType: NotationTypes;
+  lastChange: DiagramChange | null;
   setEdgesOrthogonal: (isOrthogonal: boolean) => void;
   onNotationChange: (newNotationType: NotationTypes) => void;
   erEdgeNotation: ErNotation["edgeMarkers"];
@@ -38,8 +40,10 @@ type ErDiagramProps = {
 const NotationSelectorErDiagramWrapper = ({
   erDoc,
   erDocHasError,
+  lastChange,
 }: {
   erDoc: ER;
+  lastChange: DiagramChange | null;
   erDocHasError: boolean;
 }) => {
   const [edgesOrthogonal, setEdgesOrthogonal] = useState<boolean>(false);
@@ -54,6 +58,7 @@ const NotationSelectorErDiagramWrapper = ({
       erDoc={erDoc}
       erDocHasError={erDocHasError}
       notation={notation}
+      lastChange={lastChange}
       erEdgeNotation={notation.edgeMarkers}
       notationType={notationType}
       onNotationChange={(newNotationType) => setNotationType(newNotationType)}
@@ -67,6 +72,7 @@ const ErDiagram = ({
   erDocHasError,
   notation,
   notationType,
+  lastChange,
   onNotationChange,
   setEdgesOrthogonal,
 }: ErDiagramProps) => {
@@ -80,91 +86,98 @@ const ErDiagram = ({
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const { fitView } = useReactFlow();
-  const {
-    autoLayoutEnabled,
-    loadedDiagramFromOutside,
-    setLoadedDiagramFromOutside,
-  } = useContext(Context);
+  const { autoLayoutEnabled } = useContext(Context);
 
   const { onNodeDrag, onNodeDragStart, onNodeDragStop } = useAlignmentGuide();
   const { saveToLocalStorage, loadFromLocalStorage, setRfInstance } =
     useDiagramToLocalStorage();
   useLayoutedElements(autoLayoutEnabled);
 
+  useEffect(() => {
+    if (lastChange?.type === "json" || lastChange?.type === "localStorage") {
+      const nodePositions = lastChange.positions.nodes;
+      setNodes((nodes) => {
+        return nodes.map((node) => {
+          const savedNode = nodePositions.find((n) => n.id === node.id);
+          if (savedNode) {
+            return {
+              ...node,
+              position: savedNode.position,
+            };
+          } else return node;
+        });
+      });
+      saveToLocalStorage();
+      setTimeout(() => window.requestAnimationFrame(() => fitView()), 3);
+    }
+  }, [lastChange, saveToLocalStorage, setNodes, fitView]);
+
   if (!erDocHasError && erDoc !== prevErDoc) {
     setPrevErDoc(erDoc);
-    // don't update the diagram if it was loaded from json or localstorage
-    if (loadedDiagramFromOutside) {
-      setLoadedDiagramFromOutside(false);
-      saveToLocalStorage();
-    } else {
-      const [fromErNodes, fromErEdges] = erToReactflowElements(
-        erDoc,
-        erEdgeNotation,
-      );
-      const renaming =
-        nodes.length === fromErNodes.length &&
-        edges.length === fromErEdges.length;
-      const hideItems = !renaming && autoLayoutEnabled;
-      // @ts-ignore
-      setNodes((nodes) => {
-        const alreadyExists: string[] = [];
-        return (
-          nodes
-            // if the node already exists, keep its position
-            .map((oldNode) => {
-              let newNode = fromErNodes.find(
-                (newNode) => newNode.data.erId === oldNode.data.erId,
+    const [fromErNodes, fromErEdges] = erToReactflowElements(
+      erDoc,
+      erEdgeNotation,
+    );
+    const renaming =
+      nodes.length === fromErNodes.length &&
+      edges.length === fromErEdges.length;
+    const hideItems = !renaming && autoLayoutEnabled;
+    // @ts-ignore
+    setNodes((nodes) => {
+      const alreadyExists: string[] = [];
+      return (
+        nodes
+          // if the node already exists, keep its position
+          .map((oldNode) => {
+            let newNode = fromErNodes.find(
+              (newNode) => newNode.data.erId === oldNode.data.erId,
+            );
+            if (!newNode && renaming) {
+              newNode = fromErNodes.find(
+                (newNode) => newNode.id === oldNode.id,
               );
-              if (!newNode && renaming) {
-                newNode = fromErNodes.find(
-                  (newNode) => newNode.id === oldNode.id,
-                );
+            }
+            if (newNode) {
+              alreadyExists.push(newNode.id);
+              newNode.position = oldNode.position;
+              // for aggregations, don't modify its size
+              if (newNode.type === "aggregation") {
+                newNode.data.height = (oldNode as AggregationNode).data.height;
+                newNode.data.width = (oldNode as AggregationNode).data.width;
               }
-              if (newNode) {
-                alreadyExists.push(newNode.id);
-                newNode.position = oldNode.position;
-                // for aggregations, don't modify its size
-                if (newNode.type === "aggregation") {
-                  newNode.data.height = (
-                    oldNode as AggregationNode
-                  ).data.height;
-                  newNode.data.width = (oldNode as AggregationNode).data.width;
-                }
-                return newNode;
-              }
-              return undefined;
-            })
-            .filter((n) => n !== undefined)
-            // hide the new nodes and add them
-            .concat(
-              fromErNodes
-                .filter((nn) => !alreadyExists.includes(nn.id))
-                .map((newNode) => ({
-                  ...newNode,
-                  style: { ...newNode.style, opacity: hideItems ? 0 : 1 },
-                })),
-            )
-        );
-      });
-
-      setEdges((oldEdges) => {
-        const alreadyExists: string[] = [];
-        return oldEdges
-          .map((oldEdge) => {
-            const updatedEdge = fromErEdges.find((ne) => ne.id === oldEdge.id);
-            if (updatedEdge) alreadyExists.push(updatedEdge.id);
-            return updatedEdge;
+              return newNode;
+            }
+            return undefined;
           })
+          .filter((n) => n !== undefined)
+          // hide the new nodes and add them
           .concat(
-            fromErEdges
-              .filter((ne) => !alreadyExists.includes(ne.id))
-              .map((e) => ({ ...e, hidden: hideItems ? true : false })),
+            fromErNodes
+              .filter((nn) => !alreadyExists.includes(nn.id))
+              .map((newNode) => ({
+                ...newNode,
+                style: { ...newNode.style, opacity: hideItems ? 0 : 1 },
+              })),
           )
-          .filter((e) => e !== undefined) as Edge[];
-      });
-      setTimeout(saveToLocalStorage, 100);
-    }
+      );
+    });
+
+    setEdges((oldEdges) => {
+      const alreadyExists: string[] = [];
+      return oldEdges
+        .map((oldEdge) => {
+          const updatedEdge = fromErEdges.find((ne) => ne.id === oldEdge.id);
+          if (updatedEdge) alreadyExists.push(updatedEdge.id);
+          return updatedEdge;
+        })
+        .concat(
+          fromErEdges
+            .filter((ne) => !alreadyExists.includes(ne.id))
+            .map((e) => ({ ...e, hidden: hideItems ? true : false })),
+        )
+        .filter((e) => e !== undefined) as Edge[];
+    });
+    setTimeout(saveToLocalStorage, 100);
   }
 
   useEffect(() => {

--- a/src/app/components/ErDiagram/ErDiagram.tsx
+++ b/src/app/components/ErDiagram/ErDiagram.tsx
@@ -95,6 +95,7 @@ const ErDiagram = ({
 
   useEffect(() => {
     if (lastChange?.type === "json" || lastChange?.type === "localStorage") {
+      console.log("Loading from", lastChange.type);
       const nodePositions = lastChange.positions.nodes;
       setNodes((nodes) => {
         return nodes.map((node) => {
@@ -107,8 +108,7 @@ const ErDiagram = ({
           } else return node;
         });
       });
-      saveToLocalStorage();
-      setTimeout(() => window.requestAnimationFrame(() => fitView()), 3);
+      setTimeout(saveToLocalStorage, 100);
     }
   }, [lastChange, saveToLocalStorage, setNodes, fitView]);
 
@@ -182,7 +182,8 @@ const ErDiagram = ({
 
   useEffect(() => {
     if (!autoLayoutEnabled) {
-      setTimeout(() => window.requestAnimationFrame(() => fitView()), 0);
+      console.log("Setting the view from old");
+      setTimeout(() => window.requestAnimationFrame(() => fitView()), 10);
     }
   }, [nodes.length, autoLayoutEnabled, fitView]);
 

--- a/src/app/components/Header/ExportButton.tsx
+++ b/src/app/components/Header/ExportButton.tsx
@@ -8,7 +8,6 @@ import { getRectOfNodes, useReactFlow } from "reactflow";
 import { DownloadFunc, downloadImage, exportToPDF } from "../../util/common";
 import { Dropdown } from "./Dropdown";
 import { ExportImageModal } from "./ExportModal";
-import { useJSON } from "../../hooks/useJSON";
 
 const ExportButton = () => {
   const flow = document.querySelector(".react-flow__viewport");
@@ -36,7 +35,6 @@ const ExportButton = () => {
     };
 
   const t = useTranslations("home.header");
-  const { exportToJSON } = useJSON();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [exportFunc, setExportFunc] = useState<DownloadFunc>(() => {});
   const [allowTransparent, setAllowTransparent] = useState<boolean>(true);

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -1,12 +1,13 @@
 import { useLocale, useTranslations } from "next-intl";
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import { useMemo, memo } from "react";
 import { BiSolidBook } from "react-icons/bi";
 import { MdDownload } from "react-icons/md";
 import AutoLayoutSwitch from "./AutoLayoutSwitch";
 import SaveLoadFileButton from "./SaveLoadFileButton";
 import NewDiagramButton from "./NewDiagramButton";
 import LocaleSwitcher from "./LocaleSwitcher";
+import { ErDocChangeEvent } from "../../types/CodeEditor";
 
 const PROJECT_GITHUB = "https://github.com/matias-lg/er";
 
@@ -27,7 +28,11 @@ const HeaderElement = ({
   </div>
 );
 
-export const Header = () => {
+type HeaderProps = {
+  onErDocChange: (evt: ErDocChangeEvent) => void;
+};
+
+export const Header = ({ onErDocChange }: HeaderProps) => {
   const t = useTranslations("home.header");
   const locale = useLocale();
   const isSpanish = locale === "es";
@@ -65,7 +70,7 @@ export const Header = () => {
         </HeaderElement>
 
         <HeaderElement className="border-l-[1px]">
-          <NewDiagramButton />
+          <NewDiagramButton onErDocChange={onErDocChange} />
         </HeaderElement>
 
         <HeaderElement className="border-l-[1px]">
@@ -74,6 +79,7 @@ export const Header = () => {
             modalTitle={t("importModal.title")}
             modalDescription={t("importModal.description")}
             modalConfirm={t("importModal.upload")}
+            onErDocChange={onErDocChange}
           />
         </HeaderElement>
 
@@ -117,4 +123,4 @@ const GitHubButton = () => {
   );
 };
 
-export default Header;
+export default memo(Header);

--- a/src/app/components/Header/NewDiagramButton.tsx
+++ b/src/app/components/Header/NewDiagramButton.tsx
@@ -15,18 +15,29 @@ import { useMonaco } from "@monaco-editor/react";
 import { useContext } from "react";
 import { useTranslations } from "next-intl";
 import { LuFilePlus } from "react-icons/lu";
+import { ErDocChangeEvent } from "../../types/CodeEditor";
 
-const NewDiagramButton = () => {
+type NewDiagramButtonProps = {
+  onErDocChange: (evt: ErDocChangeEvent) => void;
+};
+
+const NewDiagramButton = ({ onErDocChange }: NewDiagramButtonProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { setLoadedDiagramFromOutside } = useContext(Context);
   const monaco = useMonaco();
   const t = useTranslations("home.header.newDiagram");
 
   const onModalButtonClick = () => {
-    // we want to trigger a diagram update event in this case
-    setLoadedDiagramFromOutside(false);
     const codeEditorModel = monaco?.editor.getModels()[0];
     codeEditorModel?.setValue("");
+    onErDocChange({
+      er: {
+        aggregations: [],
+        entities: [],
+        relationships: [],
+      },
+      type: "userInput",
+    });
     onClose();
   };
 

--- a/src/app/components/Header/NewDiagramButton.tsx
+++ b/src/app/components/Header/NewDiagramButton.tsx
@@ -10,9 +10,7 @@ import {
   ModalOverlay,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Context } from "../../context";
 import { useMonaco } from "@monaco-editor/react";
-import { useContext } from "react";
 import { useTranslations } from "next-intl";
 import { LuFilePlus } from "react-icons/lu";
 import { ErDocChangeEvent } from "../../types/CodeEditor";
@@ -23,7 +21,6 @@ type NewDiagramButtonProps = {
 
 const NewDiagramButton = ({ onErDocChange }: NewDiagramButtonProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { setLoadedDiagramFromOutside } = useContext(Context);
   const monaco = useMonaco();
   const t = useTranslations("home.header.newDiagram");
 

--- a/src/app/components/Header/SaveLoadFileButton.tsx
+++ b/src/app/components/Header/SaveLoadFileButton.tsx
@@ -15,6 +15,7 @@ import { LuFileJson } from "react-icons/lu";
 import { useJSON } from "../../hooks/useJSON";
 import { Dropdown } from "./Dropdown";
 import { useTranslations } from "next-intl";
+import { ErDocChangeEvent } from "../../types/CodeEditor";
 
 const validate = (json: any): boolean => {
   if (!json.erDoc) return false;
@@ -44,14 +45,16 @@ const SaveLoadFileButton = ({
   modalTitle,
   modalDescription,
   modalConfirm,
+  onErDocChange,
 }: {
   title: string;
   modalTitle: string;
   modalDescription: string;
   modalConfirm: string;
+  onErDocChange: (evt: ErDocChangeEvent) => void;
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { importJSON, exportToJSON } = useJSON();
+  const { importJSON, exportToJSON } = useJSON(onErDocChange);
   const t = useTranslations("home.header.saveLoad");
 
   let fileRef = useRef<HTMLInputElement | null>(null);

--- a/src/app/context.ts
+++ b/src/app/context.ts
@@ -3,15 +3,11 @@ import { createContext, Dispatch, SetStateAction } from "react";
 type ContextProps = {
   autoLayoutEnabled: boolean | null;
   setAutoLayoutEnabled: Dispatch<SetStateAction<boolean | null>>;
-  loadedDiagramFromOutside: boolean;
-  setLoadedDiagramFromOutside: Dispatch<SetStateAction<boolean>>;
 };
 
 const Context = createContext<ContextProps>({
   autoLayoutEnabled: true,
   setAutoLayoutEnabled: () => {},
-  loadedDiagramFromOutside: false,
-  setLoadedDiagramFromOutside: () => {},
 });
 
 export { Context };

--- a/src/app/hooks/useDiagramToLocalStorage.tsx
+++ b/src/app/hooks/useDiagramToLocalStorage.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useState } from "react";
 import { ReactFlowInstance, useReactFlow } from "reactflow";
-import { Context } from "../context";
 
 const LOCAL_STORAGE_FLOW_KEY = "er-flow";
 
@@ -15,14 +14,11 @@ export const useDiagramToLocalStorage = () => {
     }
   }, [rfInstance]);
 
-  const { setLoadedDiagramFromOutside } = useContext(Context);
-
   const loadFromLocalStorage = () => {
     const storedFlow = localStorage.getItem(LOCAL_STORAGE_FLOW_KEY);
     if (storedFlow) {
       const flow = JSON.parse(storedFlow);
       const { x = 0, y = 0, zoom = 1 } = flow.viewport;
-      setLoadedDiagramFromOutside(true);
       setNodes(() => {
         return flow.nodes || [];
       });

--- a/src/app/hooks/useJSON.tsx
+++ b/src/app/hooks/useJSON.tsx
@@ -40,8 +40,7 @@ const exportObject = (object: any, filename: string) => {
 export const useJSON = (onErDocChange: (evt: ErDocChangeEvent) => void) => {
   const { getNodes, getEdges } = useReactFlow();
   const monaco = useMonaco();
-  const { setAutoLayoutEnabled, setLoadedDiagramFromOutside } =
-    useContext(Context);
+  const { setAutoLayoutEnabled } = useContext(Context);
 
   const exportToJSON = () => {
     const filename = "er-diagram.json";
@@ -75,13 +74,11 @@ export const useJSON = (onErDocChange: (evt: ErDocChangeEvent) => void) => {
     // first, turn off auto layout
     setAutoLayoutEnabled(false);
     // set the text in monaco
-    setLoadedDiagramFromOutside(false);
     if (monacoInstance) {
       monacoInstance.editor.getModels()[0].setValue(editorText);
     } else {
       monaco?.editor.getModels()[0].setValue(editorText);
     }
-
     onErDocChange({
       type: "json",
       positions: {
@@ -89,25 +86,6 @@ export const useJSON = (onErDocChange: (evt: ErDocChangeEvent) => void) => {
         edges: json.edges,
       },
     });
-
-    // HACK: setting the editor value will trigger an OnChange event which will cause the
-    // ER Diagram to be updated to the nodes with default positions, we need to wait for that
-    // to happen and then update the positions. There's probably a better way to do this.
-    // setTimeout(() => {
-    //   setLoadedDiagramFromOutside(true);
-    //   setNodes((nodes) => {
-    //     return nodes.map((node) => {
-    //       const savedNode = json.nodes.find((n) => n.id === node.id);
-    //       if (savedNode) {
-    //         return {
-    //           ...node,
-    //           position: savedNode.position,
-    //         };
-    //       } else return node;
-    //     });
-    //   });
-    //   setTimeout(() => window.requestAnimationFrame(() => fitView()), 1);
-    // }, 1);
   };
 
   return { exportToJSON, importJSON };

--- a/src/app/types/CodeEditor.ts
+++ b/src/app/types/CodeEditor.ts
@@ -33,3 +33,16 @@ export type ErDocChangeEvent =
       type: "localStorage";
       positions: ErEventPositions;
     };
+
+export type DiagramChange =
+  | {
+      type: "userInput";
+    }
+  | {
+      type: "json";
+      positions: ErEventPositions;
+    }
+  | {
+      type: "localStorage";
+      positions: ErEventPositions;
+    };

--- a/src/app/types/CodeEditor.ts
+++ b/src/app/types/CodeEditor.ts
@@ -1,4 +1,6 @@
+import { ER } from "../../ERDoc/types/parser/ER";
 import { TokenLocation } from "../../ERDoc/types/parser/TokenLocation";
+import { ErJSON } from "../hooks/useJSON";
 
 // from 'monaco-editor', importing it directly causes a conflict with SSR
 export enum MarkerSeverity {
@@ -12,3 +14,22 @@ export type ErrorMessage = {
   errorMessage: string;
   location: TokenLocation;
 };
+
+type ErEventPositions = {
+  nodes: ErJSON["nodes"];
+  edges: ErJSON["edges"];
+};
+
+export type ErDocChangeEvent =
+  | {
+      type: "userInput";
+      er: ER;
+    }
+  | {
+      type: "json";
+      positions: ErEventPositions;
+    }
+  | {
+      type: "localStorage";
+      positions: ErEventPositions;
+    };


### PR DESCRIPTION
Loading examples, or creating blank diagrams sometimes caused the text editor and the diagram to get out of sync.
Now we pass "er model change events" to the diagram. So it acts different when a diagram changed from the load of a file, from an example or from user input.